### PR TITLE
docs: update e2e testing guidance for real engine flows

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -76,6 +76,10 @@ pip install pytest pytest-asyncio pytest-timeout
 poetry install --with test
 ```
 
+The suite spins up lightweight services for connectors on demand. Docker is optional, but having it installed allows the
+database fixtures to provision ephemeral Postgres instances. When Docker is unavailable the fixtures fall back to
+in-process SQLite adapters so the real connectors can still exercise the write path.
+
 ### Quick Start
 ```bash
 # Run all E2E tests
@@ -124,26 +128,85 @@ pytest test_fault_tolerance_e2e.py::TestFaultToleranceE2E::test_circuit_breaker_
 
 ## Test Structure
 
-### Fixtures (`conftest.py`)
-- `temp_dirs`: Temporary directories for pipeline artifacts
-- `mock_pipeline_id`: Unique pipeline ID for test isolation
-- `data_generator`: Generate various types of test data
-- `mock_connector_factory`: Create mock connectors with failure patterns
-- `fault_tolerance_config`: Standard fault tolerance configuration
+### Fixture-Orchestrated Real Pipelines (`conftest.py`)
+The E2E suite provisions full pipelines instead of swapping out the `StreamingEngine`.
+Core fixtures coordinate configuration, runtime services, and cleanup:
 
-### Mock Components
-- **DataGenerator**: Generates valid, malformed, and large datasets
-- **MockConnectorFactory**: Creates failing connectors with various patterns
-- **FaultInjectionConnector**: Simulates specific failure scenarios
-- **NetworkResilientConnector**: Simulates network resilience scenarios
+- `temp_dirs`: Creates isolated state, log, config, and DLQ directories per test run.
+- `mock_pipeline_id`: Provides unique pipeline identifiers for concurrent runs (name retained for backward compatibility).
+- `data_generator`: Builds synthetic record sets that are fed into real sources.
+- `fault_tolerance_config`: Supplies shared retry/circuit breaker defaults.
+- **Pipeline runner fixtures**: Helpers that instantiate `analitiq_stream.core.pipeline.Pipeline`, await `pipeline.run()`, and
+  return collected metrics for assertions. These fixtures guarantee the actual `StreamingEngine` is used and handle
+  teardown of engine background tasks.
+- **Stub connector/service fixtures**: Async factories that spin up lightweight HTTP and database services (using
+  `aiohttp`, `sqlite`, or disposable containers) so connectors interact with real endpoints. Each fixture returns
+  connection dictionaries compatible with the production connectors bundled in `analitiq_stream.connectors`.
+
+### Stub Services and Data Contracts
+- **HTTP/API stubs** expose deterministic paginated responses, throttling hooks, and failure toggles for testing
+  back-pressure and retry flows.
+- **Database stubs** (e.g., ephemeral Postgres or SQLite instances) are seeded with fixture data and validated after runs
+  to assert record writes, upsert semantics, and constraint handling.
+- **Fault injection adapters** wrap the stub services so tests can toggle latency, error codes, or dropped batches while
+  the real engine is processing records.
 
 ### Test Patterns
-Each test follows a consistent pattern:
+Each test follows a consistent pattern without mocking the engine:
 
-1. **Setup**: Configure pipeline with specific edge case settings
-2. **Mock**: Create mock connectors simulating failure conditions
-3. **Execute**: Run pipeline with mocked StreamingEngine
-4. **Verify**: Assert metrics and behavior match expected edge case handling
+1. **Setup**: Compose pipeline configuration, register stub services, and seed input data.
+2. **Provision**: Use fixtures to boot the required connectors/services and build fully merged source/destination configs.
+3. **Execute**: Instantiate `Pipeline` and call `await pipeline.run()` so the real `StreamingEngine` processes the stream.
+4. **Verify**: Inspect metrics, DLQ output, and stub service state to confirm behavior matches expectations.
+
+#### Example: Exercising the Engine Without Patching
+```python
+@pytest.mark.asyncio
+async def test_retry_exhaustion(
+    temp_dirs,
+    mock_pipeline_id,
+    fault_tolerance_config,
+    data_generator,
+    api_stub_source,
+    postgres_stub_destination,
+):
+    """Stream real records through the engine and assert DLQ + retries."""
+
+    source_config = api_stub_source(records=data_generator.generate_valid_records(6), failure_rate=0.5)
+    destination_config = postgres_stub_destination()
+
+    pipeline_config = {
+        "pipeline_id": mock_pipeline_id,
+        "name": "API to warehouse",
+        "version": "1.0",
+        "engine_config": {"batch_size": 3, "max_concurrent_batches": 1},
+        "streams": {
+            "orders": {
+                "name": "orders",
+                "src": {"endpoint_id": source_config["endpoint_id"], "fault_tolerance": fault_tolerance_config},
+                "dst": {"endpoint_id": destination_config["endpoint_id"]},
+            }
+        },
+        "error_handling": {"strategy": "dlq", "max_retries": 3},
+    }
+
+    pipeline = Pipeline(
+        pipeline_config=pipeline_config,
+        source_config=source_config,
+        destination_config=destination_config,
+        state_dir=str(temp_dirs["state"]),
+    )
+
+    await pipeline.run()
+    metrics = pipeline.get_metrics()
+
+    assert metrics["records_failed"] > 0
+    assert metrics["retry_attempts"] >= metrics["records_failed"]
+    assert postgres_stub_destination.rows_written("orders") > 0
+```
+
+The stub fixtures provide connection dictionaries and helper assertions (like `rows_written`) while ensuring the actual
+engine performs all scheduling, batching, and retry logic.
 
 ## Edge Cases Covered
 
@@ -197,11 +260,11 @@ Tests verify comprehensive metrics including:
 4. **Deterministic Behavior**: Use controlled randomness with seeds
 5. **Clear Assertions**: Verify both positive and negative outcomes
 
-### Mock Design
-1. **Realistic Failures**: Mirror actual system failure modes
-2. **Configurable Patterns**: Allow tuning failure rates and types
-3. **State Tracking**: Record operations for verification
-4. **Resource Management**: Proper cleanup and resource release
+### Stub Service Design
+1. **Protocol Fidelity**: Match real connector contracts (headers, pagination, SQL schemas).
+2. **Configurable Failures**: Expose knobs for latency, HTTP status overrides, transaction rollbacks, or disk pressure.
+3. **Observability Hooks**: Capture incoming requests/queries for post-run assertions and debugging.
+4. **Deterministic Cleanup**: Ensure temporary ports, event loops, and containers are shut down after each test.
 
 ### Performance Considerations
 1. **Timeout Configuration**: Set appropriate timeouts for long-running tests
@@ -214,14 +277,14 @@ Tests verify comprehensive metrics including:
 ### Common Issues
 1. **Test Timeouts**: Increase timeout or optimize test data size
 2. **Resource Conflicts**: Ensure unique pipeline IDs and temp directories
-3. **Mock Failures**: Verify mock configuration matches test expectations
+3. **Stub Failures**: Confirm stub services are reachable and seeded with expected data
 4. **Async Issues**: Ensure proper async/await usage in test code
 
 ### Debugging Tips
 1. **Verbose Mode**: Use `--verbose` flag for detailed output
 2. **Single Test**: Run individual tests for focused debugging
 3. **Log Analysis**: Check pipeline logs in temp directories
-4. **Mock Inspection**: Examine mock operation history
+4. **Stub Inspection**: Review captured HTTP requests, SQL logs, or fixture metrics
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- refresh the E2E README to explain the real StreamingEngine execution model
- document the fixture strategy that spins up stub HTTP and database services
- replace mock-oriented guidance with examples that run the actual engine

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cad0ab980c83218099cedc49ed2758