### PR TITLE
Merge pipeline and stream credentials for connectors

### DIFF
--- a/analitiq_stream/core/engine.py
+++ b/analitiq_stream/core/engine.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from asyncio import Queue, Semaphore
+from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, AsyncIterator, Tuple
 from uuid import uuid4
@@ -29,6 +30,23 @@ from .exceptions import (
 from .orchestrator import PipelineOrchestrator
 
 logger = logging.getLogger(__name__)
+
+
+def _deep_merge_dicts(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge two dictionaries without mutating inputs."""
+
+    merged = deepcopy(base)
+
+    for key, value in override.items():
+        if (
+            isinstance(value, dict)
+            and isinstance(merged.get(key), dict)
+        ):
+            merged[key] = _deep_merge_dicts(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+
+    return merged
 
 
 class StreamingEngine:
@@ -80,6 +98,7 @@ class StreamingEngine:
 
         # Fault tolerance components with state management
         self.sharded_state_manager = StateManager(pipeline_id, str(DIRECTORIES["state"]))
+        self._state_manager = self.sharded_state_manager
         self.retry_handler = RetryHandler()
         self.circuit_breaker = CircuitBreaker()
         self.dlq = DeadLetterQueue(self.engine_config.dlq_path)
@@ -114,7 +133,7 @@ class StreamingEngine:
         logger.info(f"Processing {len(streams)} streams concurrently")
             
         # Start new run
-        run_id = self.sharded_state_manager.start_run(pipeline_config)
+        run_id = self.state_manager.start_run(pipeline_config)
         logger.info(f"Started state run: {run_id}")
 
         stream_exceptions = []
@@ -208,21 +227,30 @@ class StreamingEngine:
         tasks = []
         
         try:
+            pipeline_src_config = pipeline_config.get("src", {})
+            pipeline_dst_config = pipeline_config.get("dst", {})
+
+            stream_src_config = stream_config.get("src", {})
+            stream_dst_config = stream_config.get("dst", {})
+
+            merged_src_config = _deep_merge_dicts(pipeline_src_config, stream_src_config)
+            merged_dst_config = _deep_merge_dicts(pipeline_dst_config, stream_dst_config)
+
             # Get connectors for this stream using factory methods
-            source_connector = self._create_source_connector(stream_config["source"])
-            dest_connector = self._create_destination_connector(stream_config["destination"])
+            source_connector = self._create_source_connector(merged_src_config)
+            dest_connector = self._create_destination_connector(merged_dst_config)
             
             # Create stream-specific DLQ
             stream_dlq_path = f"{self.dlq.dlq_path}/{stream_id}"
             stream_dlq = DeadLetterQueue(stream_dlq_path)
             
-            # Connect to source and destination
-            await source_connector.connect(stream_config["source"])
-            await dest_connector.connect(stream_config["destination"])
-            
+            # Connect to source and destination using merged configs
+            await source_connector.connect(merged_src_config)
+            await dest_connector.connect(merged_dst_config)
+
             # Configure destination if it supports configuration (e.g., DatabaseConnector)
             if hasattr(dest_connector, 'configure'):
-                await dest_connector.configure(stream_config["destination"])
+                await dest_connector.configure(merged_dst_config)
             
             # Create async queues for pipeline stages
             extract_queue = Queue(maxsize=self.buffer_size)
@@ -236,6 +264,8 @@ class StreamingEngine:
                 "stream_id": stream_id,
                 "stream_name": stream_name,
                 "stream_config": stream_config,  # Keep original for reference
+                "src": merged_src_config,
+                "dst": merged_dst_config,
             }
 
             # Start pipeline stages for this stream using factory method
@@ -282,7 +312,7 @@ class StreamingEngine:
         logger.debug(f"Starting extract stage for stream {stream_name}")
 
         try:
-            source_config = config["source"].copy()
+            source_config = config["src"].copy()
             # Add full config for state access
             source_config["pipeline_config"] = config
             
@@ -305,7 +335,7 @@ class StreamingEngine:
             # Use state management with API connector
             async for batch in source_connector.read_batches(
                 source_config,
-                state_manager=self.sharded_state_manager,
+                state_manager=self.state_manager,
                 stream_name=state_stream_name,
                 partition=partition,
                 batch_size=self.batch_size
@@ -374,7 +404,7 @@ class StreamingEngine:
                     logger.debug(f"Stream {stream_name}: Starting write_batch for batch {batch_count + 1} with {len(batch)} records")
                     # Apply semaphore for concurrency control
                     async with self.semaphore:
-                        await dest_connector.write_batch(batch, config["destination"])
+                        await dest_connector.write_batch(batch, config["dst"])
                     logger.debug(f"Stream {stream_name}: Completed write_batch for batch {batch_count + 1}")
                     
                     await output_queue.put(batch)  # Forward for checkpointing
@@ -482,8 +512,8 @@ class StreamingEngine:
     def _get_stream_name(self, config: Dict[str, Any]) -> str:
         """Generate stream name for state management."""
         # Use endpoint ID as stream name
-        if "source" in config and "endpoint_id" in config["source"]:
-            return f"endpoint.{config['source']['endpoint_id']}"
+        if "src" in config and "endpoint_id" in config["src"]:
+            return f"endpoint.{config['src']['endpoint_id']}"
         else:
             return config.get("pipeline_id", "unknown-stream")
 
@@ -493,4 +523,20 @@ class StreamingEngine:
 
     def get_state_manager(self) -> StateManager:
         """Get the state manager instance."""
-        return self.sharded_state_manager
+        return self.state_manager
+
+    @property
+    def state_manager(self) -> StateManager:
+        """State manager accessor for backward compatibility with legacy tests."""
+        return self._state_manager
+
+    @state_manager.setter
+    def state_manager(self, value: StateManager) -> None:
+        """Allow tests to override the state manager and keep aliases in sync."""
+        self._state_manager = value
+        self.sharded_state_manager = value
+
+    @state_manager.deleter
+    def state_manager(self) -> None:
+        """Restore the default state manager when patched contexts exit."""
+        self._state_manager = self.sharded_state_manager

--- a/analitiq_stream/core/pipeline.py
+++ b/analitiq_stream/core/pipeline.py
@@ -297,8 +297,8 @@ class Pipeline:
         for stream_id, stream_config in self.config["streams"].items():
             streams_info[stream_id] = {
                 "name": stream_config.get("name", stream_id),
-                "source": stream_config.get("source", {}).get("endpoint_id", "unknown"),
-                "destination": stream_config.get("destination", {}).get("endpoint_id", "unknown"),
+                "source": stream_config.get("src", {}).get("endpoint_id", "unknown"),
+                "destination": stream_config.get("dst", {}).get("endpoint_id", "unknown"),
             }
         
         return {

--- a/tests/unit/analitiq_stream/core/test_engine_unit.py
+++ b/tests/unit/analitiq_stream/core/test_engine_unit.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
-from analitiq_stream.core.engine import StreamingEngine
+from analitiq_stream.core.engine import StreamingEngine, _deep_merge_dicts
 from analitiq_stream.core.exceptions import ConfigurationError, StreamProcessingError
 
 
@@ -174,14 +174,106 @@ class TestStreamingEngine:
                 with patch('asyncio.create_task') as mock_create_task:
                     # Return mock tasks
                     mock_create_task.side_effect = lambda coro, name=None: AsyncMock()
-                    
+
                     try:
                         await engine.stream_data(config)
                     except (ExceptionGroup, Exception):
                         pass  # We expect exceptions
-                    
+
                     # Verify create_task was called for each stream
                     assert mock_create_task.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_process_stream_uses_merged_credentials(self, engine):
+        """Connector creation should receive deep-merged src/dst credentials."""
+
+        pipeline_config = {
+            "pipeline_id": "test-pipeline",
+            "name": "Test Pipeline",
+            "version": "1.0",
+            "src": {
+                "type": "api",
+                "base_url": "https://root.example.com",
+                "headers": {
+                    "Authorization": "Bearer root-token",
+                    "User-Agent": "root-agent",
+                    "nested": {"base": True},
+                },
+                "auth": {"token": "root-token"},
+            },
+            "dst": {
+                "type": "database",
+                "driver": "postgresql",
+                "host": "root.db.local",
+                "port": 5432,
+                "database": "analytics",
+                "user": "pipeline",
+                "password": "secret",
+                "options": {
+                    "sslmode": "require",
+                    "pool": {"min": 1, "max": 5},
+                },
+            },
+            "streams": {},
+        }
+
+        stream_config = {
+            "name": "users",
+            "src": {
+                "endpoint_id": "endpoint-123",
+                "headers": {
+                    "User-Agent": "stream-agent",
+                    "X-Stream": "value",
+                    "nested": {"override": True},
+                },
+                "pagination": {"type": "page"},
+            },
+            "dst": {
+                "endpoint_id": "endpoint-456",
+                "table": "users",
+                "options": {
+                    "pool": {"max": 10},
+                    "schema": "public",
+                },
+            },
+            "mapping": {},
+        }
+
+        pipeline_config["streams"]["users"] = stream_config
+
+        expected_src = _deep_merge_dicts(pipeline_config["src"], stream_config["src"])
+        expected_dst = _deep_merge_dicts(pipeline_config["dst"], stream_config["dst"])
+
+        source_connector = Mock()
+        source_connector.connect = AsyncMock()
+        source_connector.disconnect = AsyncMock()
+
+        dest_connector = Mock()
+        dest_connector.connect = AsyncMock()
+        dest_connector.configure = AsyncMock()
+        dest_connector.disconnect = AsyncMock()
+
+        with (
+            patch.object(engine, "_create_source_connector", return_value=source_connector) as mock_create_src,
+            patch.object(engine, "_create_destination_connector", return_value=dest_connector) as mock_create_dst,
+            patch.object(engine, "_create_pipeline_stages", return_value=[]) as mock_create_stages,
+        ):
+
+            await engine._process_stream("users", stream_config, pipeline_config)
+
+        mock_create_src.assert_called_once_with(expected_src)
+        mock_create_dst.assert_called_once_with(expected_dst)
+        source_connector.connect.assert_awaited_once_with(expected_src)
+        dest_connector.connect.assert_awaited_once_with(expected_dst)
+        dest_connector.configure.assert_awaited_once_with(expected_dst)
+
+        assert mock_create_stages.call_count == 1
+        stage_kwargs = mock_create_stages.call_args.kwargs
+        assert stage_kwargs["stream_processing_config"]["src"] == expected_src
+        assert stage_kwargs["stream_processing_config"]["dst"] == expected_dst
+
+        source_connector.disconnect.assert_awaited_once()
+        dest_connector.disconnect.assert_awaited_once()
 
     def test_get_connector_api(self, engine):
         """Test connector creation for API type."""
@@ -231,7 +323,7 @@ class TestStreamingEngine:
     def test_get_stream_name(self, engine):
         """Test stream name generation."""
         # With endpoint ID
-        config = {"source": {"endpoint_id": "test-endpoint-123"}}
+        config = {"src": {"endpoint_id": "test-endpoint-123"}}
         result = engine._get_stream_name(config)
         assert result == "endpoint.test-endpoint-123"
         


### PR DESCRIPTION
## Summary
- deep-merge pipeline and stream src/dst config dictionaries before building connectors and stage configs, and expose a state manager property for legacy patches
- update pipeline status reporting and stream name derivation to use the merged src/dst keys
- add unit coverage proving merged credentials reach API and database connector construction

## Testing
- `PYTHONPATH=. pytest tests/unit/analitiq_stream/core/test_engine_unit.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd8c0dc3048321aecf672acd22218c