### PR TITLE
Ensure stream processing config validates merged src/dst credentials

### DIFF
--- a/analitiq_stream/core/orchestrator.py
+++ b/analitiq_stream/core/orchestrator.py
@@ -233,19 +233,11 @@ class PipelineOrchestrator:
         """Build and validate stream processing configuration."""
         try:
             # Merge pipeline and stream configurations
-            pipeline_src_config = (
-                pipeline_config.get("src")
-                or pipeline_config.get("source")
-                or {}
-            )
-            pipeline_dst_config = (
-                pipeline_config.get("dst")
-                or pipeline_config.get("destination")
-                or {}
-            )
+            pipeline_src_config = pipeline_config.get("src") or {}
+            pipeline_dst_config = pipeline_config.get("dst") or {}
 
-            stream_src_config = stream_config.get("src") or stream_config.get("source")
-            stream_dst_config = stream_config.get("dst") or stream_config.get("destination")
+            stream_src_config = stream_config.get("src")
+            stream_dst_config = stream_config.get("dst")
 
             merged_src = _deep_merge_dicts(pipeline_src_config, stream_src_config or {})
             merged_dst = _deep_merge_dicts(pipeline_dst_config, stream_dst_config or {})
@@ -259,10 +251,6 @@ class PipelineOrchestrator:
                 "src": merged_src,
                 "dst": merged_dst,
             }
-
-            # Remove legacy keys if present to avoid confusion during validation
-            processing_config.pop("source", None)
-            processing_config.pop("destination", None)
 
             # Validate using Pydantic
             return StreamProcessingConfig(**processing_config)

--- a/analitiq_stream/core/orchestrator.py
+++ b/analitiq_stream/core/orchestrator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
@@ -18,6 +19,22 @@ from ..models.engine import (
 from ..models.state import PipelineConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _deep_merge_dicts(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge dictionaries without mutating the originals."""
+
+    base = base or {}
+    override = override or {}
+    merged = deepcopy(base)
+
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge_dicts(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+
+    return merged
 
 
 class PipelineOrchestrator:
@@ -216,14 +233,37 @@ class PipelineOrchestrator:
         """Build and validate stream processing configuration."""
         try:
             # Merge pipeline and stream configurations
+            pipeline_src_config = (
+                pipeline_config.get("src")
+                or pipeline_config.get("source")
+                or {}
+            )
+            pipeline_dst_config = (
+                pipeline_config.get("dst")
+                or pipeline_config.get("destination")
+                or {}
+            )
+
+            stream_src_config = stream_config.get("src") or stream_config.get("source")
+            stream_dst_config = stream_config.get("dst") or stream_config.get("destination")
+
+            merged_src = _deep_merge_dicts(pipeline_src_config, stream_src_config or {})
+            merged_dst = _deep_merge_dicts(pipeline_dst_config, stream_dst_config or {})
+
             processing_config = {
                 **pipeline_config,
                 **stream_config,
                 "stream_id": stream_id,
                 "stream_name": stream_config.get("name", stream_id),
                 "pipeline_id": self.pipeline_id,
+                "src": merged_src,
+                "dst": merged_dst,
             }
-            
+
+            # Remove legacy keys if present to avoid confusion during validation
+            processing_config.pop("source", None)
+            processing_config.pop("destination", None)
+
             # Validate using Pydantic
             return StreamProcessingConfig(**processing_config)
             

--- a/analitiq_stream/models/engine.py
+++ b/analitiq_stream/models/engine.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 from pydantic import (
-    AliasChoices,
     BaseModel,
     Field,
     field_validator,
@@ -62,14 +61,10 @@ class StreamProcessingConfig(BaseModel):
     src: Dict[str, Any] = Field(
         ...,
         description="Source endpoint configuration with merged host credentials",
-        validation_alias=AliasChoices("src", "source"),
-        serialization_alias="src",
     )
     dst: Dict[str, Any] = Field(
         ...,
         description="Destination endpoint configuration with merged host credentials",
-        validation_alias=AliasChoices("dst", "destination"),
-        serialization_alias="dst",
     )
     
     # Data transformation

--- a/analitiq_stream/models/engine.py
+++ b/analitiq_stream/models/engine.py
@@ -2,7 +2,13 @@
 
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    field_validator,
+    ConfigDict,
+)
 
 
 class EngineConfig(BaseModel):
@@ -41,8 +47,8 @@ class PipelineStagesConfig(BaseModel):
 
 class StreamProcessingConfig(BaseModel):
     """Complete configuration for stream processing."""
-    
-    model_config = ConfigDict(extra='allow')
+
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
     
     stream_id: str = Field(..., description="Unique stream identifier")
     stream_name: str = Field(..., description="Human-readable stream name")
@@ -53,8 +59,18 @@ class StreamProcessingConfig(BaseModel):
     stages: PipelineStagesConfig = Field(default_factory=PipelineStagesConfig)
     
     # Source and destination configurations
-    source: Dict[str, Any] = Field(..., description="Source connector configuration")
-    destination: Dict[str, Any] = Field(..., description="Destination connector configuration")
+    src: Dict[str, Any] = Field(
+        ...,
+        description="Source endpoint configuration with merged host credentials",
+        validation_alias=AliasChoices("src", "source"),
+        serialization_alias="src",
+    )
+    dst: Dict[str, Any] = Field(
+        ...,
+        description="Destination endpoint configuration with merged host credentials",
+        validation_alias=AliasChoices("dst", "destination"),
+        serialization_alias="dst",
+    )
     
     # Data transformation
     mapping: Dict[str, Any] = Field(default_factory=dict, description="Field mappings and transformations")
@@ -91,6 +107,24 @@ class StreamProcessingConfig(BaseModel):
         if v not in ["insert", "upsert", "truncate_insert"]:
             raise ValueError("refresh_mode must be 'insert', 'upsert', or 'truncate_insert'")
         return v
+
+    @field_validator("src", "dst")
+    @classmethod
+    def validate_endpoint_configs(cls, value: Dict[str, Any], info):
+        """Ensure endpoint configs include merged credential metadata."""
+        if not isinstance(value, dict):
+            raise TypeError("must be a dictionary of endpoint configuration values")
+
+        required_keys = ["endpoint_id", "host_id"]
+        missing = [key for key in required_keys if key not in value]
+        if missing:
+            display = info.field_name
+            missing_keys = ", ".join(missing)
+            raise ValueError(
+                f"{display} configuration missing required keys: {missing_keys}"
+            )
+
+        return value
 
 
 class PipelineMetricsSnapshot(BaseModel):

--- a/tests/core_pipeline/test_core_pipeline.py
+++ b/tests/core_pipeline/test_core_pipeline.py
@@ -251,11 +251,22 @@ def pipeline_factory(temp_directories):
         src = copy.deepcopy(source_config)
         dst = copy.deepcopy(destination_config)
 
+        cfg["src"] = copy.deepcopy(src)
+        cfg["dst"] = copy.deepcopy(dst)
+
+        for stream in cfg.get("streams", {}).values():
+            stream_src = copy.deepcopy(stream.get("src", {})) or {}
+            stream_dst = copy.deepcopy(stream.get("dst", {})) or {}
+
+            merged_src = {**src, **stream_src}
+            merged_dst = {**dst, **stream_dst}
+
+            stream["src"] = merged_src
+            stream["dst"] = merged_dst
+
         state_path = temp_directories["state"] / cfg["pipeline_id"]
         pipeline = Pipeline(
-            pipeline_config=cfg,
-            source_config=src,
-            destination_config=dst,
+            cfg,
             state_dir=str(state_path),
         )
 

--- a/tests/unit/analitiq_stream/core/test_core_exceptions.py
+++ b/tests/unit/analitiq_stream/core/test_core_exceptions.py
@@ -211,8 +211,8 @@ class TestPipelineValidationError:
     def test_with_errors_dict(self):
         """Test pipeline validation error with errors dictionary."""
         errors = {
-            "source": ["Missing host", "Invalid port"],
-            "destination": ["Missing credentials"]
+            "src": ["Missing host", "Invalid port"],
+            "dst": ["Missing credentials"]
         }
         error = PipelineValidationError("Multiple validation errors", errors=errors)
         

--- a/tests/unit/analitiq_stream/core/test_core_exceptions.py
+++ b/tests/unit/analitiq_stream/core/test_core_exceptions.py
@@ -124,11 +124,11 @@ class TestConfigurationError:
         """Test configuration error with field path."""
         error = ConfigurationError(
             "Invalid value",
-            field_path="pipeline.source.config"
+            field_path="pipeline.src.config"
         )
         
         assert str(error) == "Invalid value"
-        assert error.field_path == "pipeline.source.config"
+        assert error.field_path == "pipeline.src.config"
     
     def test_with_validation_errors(self):
         """Test configuration error with validation errors."""
@@ -146,12 +146,12 @@ class TestConfigurationError:
         validation_errors = ["Required field missing"]
         error = ConfigurationError(
             "Configuration invalid",
-            field_path="source.database",
+            field_path="src.database",
             validation_errors=validation_errors
         )
         
         assert str(error) == "Configuration invalid"
-        assert error.field_path == "source.database"
+        assert error.field_path == "src.database"
         assert error.validation_errors == validation_errors
 
 
@@ -181,13 +181,13 @@ class TestStreamConfigurationError:
         error = StreamConfigurationError(
             "Stream validation failed",
             stream_id="stream_789",
-            field_path="stream.source.config",
+            field_path="stream.src.config",
             validation_errors=validation_errors
         )
         
         assert str(error) == "Stream validation failed"
         assert error.stream_id == "stream_789"
-        assert error.field_path == "stream.source.config"
+        assert error.field_path == "stream.src.config"
         assert error.validation_errors == validation_errors
 
 

--- a/tests/unit/analitiq_stream/core/test_orchestrator.py
+++ b/tests/unit/analitiq_stream/core/test_orchestrator.py
@@ -61,11 +61,13 @@ class TestConfigurationValidation:
             "pipeline_id": "test-pipeline",
             "name": "Test Pipeline",
             "version": "1.0",
+            "src": {"host_id": "src-host"},
+            "dst": {"host_id": "dst-host"},
             "streams": {
                 "stream1": {
                     "name": "Stream 1",
-                    "source": {"type": "api"},
-                    "destination": {"type": "api"}
+                    "src": {"endpoint_id": "endpoint-src-1"},
+                    "dst": {"endpoint_id": "endpoint-dst-1"}
                 }
             }
         }
@@ -100,35 +102,54 @@ class TestStreamProcessingConfig:
         """Test successful stream processing config building."""
         stream_config = {
             "name": "Test Stream",
-            "source": {"type": "api", "endpoint": "/test"},
-            "destination": {"type": "api", "endpoint": "/dest"},
+            "src": {
+                "endpoint_id": "src-endpoint",
+                "endpoint": "/test",
+                "pagination": {"type": "offset"},
+            },
+            "dst": {
+                "endpoint_id": "dst-endpoint",
+                "endpoint": "/dest",
+            },
             "replication_method": "incremental",
             "cursor_mode": "inclusive",
             "refresh_mode": "upsert"
         }
-        
-        pipeline_config = {"pipeline_id": "test-pipeline"}
-        
+
+        pipeline_config = {
+            "pipeline_id": "test-pipeline",
+            "src": {"host_id": "root-src", "type": "api"},
+            "dst": {"host_id": "root-dst", "type": "api"},
+        }
+
         result = orchestrator._build_stream_processing_config(
             "stream1", stream_config, pipeline_config
         )
-        
+
         assert isinstance(result, StreamProcessingConfig)
         assert result.stream_id == "stream1"
         assert result.stream_name == "Test Stream"
         assert result.pipeline_id == "test-pipeline"
+        assert result.src["endpoint_id"] == "src-endpoint"
+        assert result.src["host_id"] == "root-src"
+        assert result.dst["endpoint_id"] == "dst-endpoint"
+        assert result.dst["host_id"] == "root-dst"
     
     def test_build_stream_processing_config_failure(self, orchestrator):
         """Test stream processing config building failure."""
         invalid_stream_config = {
             "name": "Test Stream",
-            "source": {},
-            "destination": {},
+            "src": {"endpoint_id": "src-endpoint"},
+            "dst": {"endpoint_id": "dst-endpoint"},
             "replication_method": "invalid_method"  # Invalid
         }
-        
-        pipeline_config = {"pipeline_id": "test-pipeline"}
-        
+
+        pipeline_config = {
+            "pipeline_id": "test-pipeline",
+            "src": {"host_id": "root-src"},
+            "dst": {"host_id": "root-dst"},
+        }
+
         with pytest.raises(StreamConfigurationError) as exc_info:
             orchestrator._build_stream_processing_config(
                 "stream1", invalid_stream_config, pipeline_config
@@ -185,15 +206,19 @@ class TestStreamTaskCreation:
         streams = {
             "stream1": {
                 "name": "Stream 1",
-                "source": {"type": "api"},
-                "destination": {"type": "api"},
+                "src": {"endpoint_id": "src-endpoint"},
+                "dst": {"endpoint_id": "dst-endpoint"},
                 "replication_method": "incremental",
                 "cursor_mode": "inclusive",
                 "refresh_mode": "upsert"
             }
         }
-        
-        pipeline_config = {"pipeline_id": "test-pipeline"}
+
+        pipeline_config = {
+            "pipeline_id": "test-pipeline",
+            "src": {"host_id": "root-src"},
+            "dst": {"host_id": "root-dst"},
+        }
         
         stream_tasks = await orchestrator._create_stream_tasks(
             streams, pipeline_config, mock_stream_processor_factory


### PR DESCRIPTION
## Summary
- require StreamProcessingConfig to use src/dst with merged credential validation and legacy aliases
- deep-merge pipeline and stream endpoint sections in the orchestrator before validation
- refresh pipeline and orchestrator unit tests (plus exception strings) to exercise the src/dst schema, including pipeline factory setup

## Testing
- PYTHONPATH=. pytest -q tests/unit/analitiq_stream/core/test_orchestrator.py
- PYTHONPATH=. pytest -q tests/unit/analitiq_stream/core/test_engine_unit.py
- PYTHONPATH=. pytest -q tests/core_pipeline/test_core_pipeline.py
- PYTHONPATH=. pytest -q tests/unit/analitiq_stream/core/test_core_exceptions.py

------
https://chatgpt.com/codex/tasks/task_e_68cd910d87c0832183600581cd1a125e