### PR TITLE
Add ConnectionRuntime to unify connection lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,6 @@ Configuration loads from local filesystem when ran locally. In cloud, `config_fe
 |----------|----------|-------------|
 | `ENV` | Yes | `local`, `dev`, `prod` - affects storage backends only |
 | `PIPELINE_ID` | Yes | Pipeline UUID |
-| `ORG_ID` | Yes | Org UUID |
 | `LOCAL_CONFIG_MOUNT` | Yes | Config directory path |
 | `AWS_REGION` | Cloud | Default: `eu-central-1` |
 
@@ -357,11 +356,11 @@ When running docker test, the run should mimic the production environment:
 
 Example:
 ```shell
-cd docker && \                                                                                                                                          
-   PIPELINE_ID=0569c85b-b538-442a-bdc5-726afca08da4 \                                                                                                                                                               
-   ORG_ID=d7a11991-2795-49d1-a858-c7e58ee5ecc6 \                                                                                                                                                                 
-   AWS_PROFILE=434659057682_AdministratorAccess \                                                                                                                                                                   
-   docker compose run --rm source_engine 2>&1 
+cd docker && \
+   PIPELINE_ID=0569c85b-b538-442a-bdc5-726afca08da4 \
+   AWS_PROFILE=434659057682_AdministratorAccess \
+   ENV=dev \
+   docker compose run --rm source_engine 2>&1
 ```
 
 ## Data Flow

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ poetry shell
 RUN_MODE=destination \
 ENV=local \
 PIPELINE_ID=<pipeline-id> \
-ORG_ID=<client-id> \
 python -m src.main
 ```
 
@@ -43,7 +42,6 @@ python -m src.main
 RUN_MODE=engine \
 ENV=local \
 PIPELINE_ID=<pipeline-id> \
-ORG_ID=<client-id> \
 DESTINATION_GRPC_HOST=localhost \
 python -m src.main
 ```
@@ -157,7 +155,6 @@ In `dev`/`prod`, `docker/config_fetcher.py` populates the consolidated pipeline 
 Common:
 - `ENV`: `local`, `dev`, `prod`
 - `PIPELINE_ID`: pipeline ID (optionally with version suffix)
-- `ORG_ID`: client UUID
 - `LOG_LEVEL`: logging level
 
 Engine mode:

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,7 +28,6 @@ cp .env.example .env
 
 ```bash
 PIPELINE_ID=<pipeline-uuid> \
-ORG_ID=<client-uuid> \
 docker compose run --rm destination
 ```
 
@@ -36,7 +35,6 @@ docker compose run --rm destination
 
 ```bash
 PIPELINE_ID=<pipeline-uuid> \
-ORG_ID=<client-uuid> \
 docker compose run --rm source_engine
 ```
 
@@ -53,8 +51,8 @@ Use the `dev.env` template and let the container fetch config from AWS.
 cp dev.env .env
 
 PIPELINE_ID=<pipeline-uuid> \
-ORG_ID=d7a11991-2795-49d1-a858-c7e58ee5ecc6 \
 AWS_PROFILE=434659057682_AdministratorAccess \
+ENV=dev \
 docker compose run --rm source_engine
 ```
 
@@ -70,7 +68,6 @@ Paths are loaded from `analitiq.yaml` at the project root.
 Set these at runtime (not in `.env`):
 
 - `PIPELINE_ID`: Pipeline UUID (optionally with version suffix).
-- `ORG_ID`: Org UUID.
 
 Optional:
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     image: analitiq-stream-cloud:latest
     container_name: analitiq-destination
 
-    # Base environment variables - per-invocation vars (PIPELINE_ID, ORG_ID)
+    # Base environment variables - per-invocation vars (PIPELINE_ID)
     # must be passed at runtime: docker compose run -e PIPELINE_ID=xxx destination
     env_file:
       - .env
@@ -25,7 +25,6 @@ services:
       - DESTINATION_INDEX=${DESTINATION_INDEX:-0}
       # Pipeline identification (required at runtime)
       - PIPELINE_ID=${PIPELINE_ID}
-      - ORG_ID=${ORG_ID}
       # AWS configuration
       - AWS_PROFILE=${AWS_PROFILE:-}
       - AWS_REGION=${AWS_REGION:-eu-central-1}
@@ -85,7 +84,7 @@ services:
     image: analitiq-stream-cloud:latest
     container_name: analitiq-source-engine
 
-    # Base environment variables - per-invocation vars (PIPELINE_ID, ORG_ID)
+    # Base environment variables - per-invocation vars (PIPELINE_ID)
     # must be passed at runtime: docker compose run -e PIPELINE_ID=xxx source_engine
     env_file:
       - .env
@@ -102,7 +101,6 @@ services:
       - ROW_COUNT_BUCKET=${ROW_COUNT_BUCKET:-analitiq-client-pipeline-row-count}
       # Pipeline identification (required at runtime)
       - PIPELINE_ID=${PIPELINE_ID}
-      - ORG_ID=${ORG_ID}
       # AWS configuration
       - AWS_PROFILE=${AWS_PROFILE:-}
 

--- a/docs/GRPC_STREAMING_ARCHITECTURE.md
+++ b/docs/GRPC_STREAMING_ARCHITECTURE.md
@@ -433,7 +433,6 @@ await server.wait_for_termination()
 |----------|----------|---------|-------------|
 | `RUN_MODE` | Yes | - | Set to `destination` for server mode |
 | `PIPELINE_ID` | Yes | - | Pipeline UUID (same as engine) |
-| `ORG_ID` | Cloud | - | Org UUID (required for cloud environments) |
 | `DESTINATION_INDEX` | No | `0` | Index of destination in pipeline config |
 | `GRPC_PORT` | No | `50051` | Port to listen on |
 | `LOG_LEVEL` | No | `INFO` | Logging level |
@@ -508,8 +507,8 @@ services:
 cd docker
 docker compose up -d destination
 
-# Run pipeline (PIPELINE_ID and ORG_ID passed at runtime)
-docker compose run -e PIPELINE_ID=<uuid> -e ORG_ID=<uuid> source_engine
+# Run pipeline (PIPELINE_ID passed at runtime)
+docker compose run -e PIPELINE_ID=<uuid> source_engine
 ```
 
 ### ECS Deployment

--- a/docs/SOURCE_CONFIG.md
+++ b/docs/SOURCE_CONFIG.md
@@ -6,7 +6,6 @@
 |----------|----------|-------------|
 | `ENV` | Yes | `local`, `dev`, `prod` |
 | `PIPELINE_ID` | Yes | Pipeline UUID |
-| `ORG_ID` | Yes | Org UUID |
 | `LOCAL_CONFIG_MOUNT` | Yes | Config directory path |
 | `AWS_REGION` | No | Default: `eu-central-1` |
 | `LOG_LEVEL` | No | Default: `INFO` |

--- a/src/destination/base_handler.py
+++ b/src/destination/base_handler.py
@@ -45,12 +45,12 @@ class BaseDestinationHandler(ABC):
     """
 
     @abstractmethod
-    async def connect(self, connection_config: Dict[str, Any]) -> None:
+    async def connect(self, runtime: "ConnectionRuntime") -> None:
         """
         Establish connection to the destination.
 
         Args:
-            connection_config: Connection parameters (host, port, credentials, etc.)
+            runtime: ConnectionRuntime with enriched config and transport factory
 
         Raises:
             ConnectionError: If connection cannot be established

--- a/src/destination/base_handler.py
+++ b/src/destination/base_handler.py
@@ -50,7 +50,7 @@ class BaseDestinationHandler(ABC):
         Establish connection to the destination.
 
         Args:
-            runtime: ConnectionRuntime with enriched config and transport factory
+            runtime: ConnectionRuntime that manages connection lifecycle
 
         Raises:
             ConnectionError: If connection cannot be established

--- a/src/destination/connectors/api.py
+++ b/src/destination/connectors/api.py
@@ -128,10 +128,9 @@ class ApiDestinationHandler(BaseDestinationHandler):
     async def disconnect(self) -> None:
         """Close API connection."""
         if self._session:
-            # RetryClient.close() does NOT close the underlying session
             await self._session.close()
         if self._runtime:
-            # Close the underlying plain session owned by the runtime
+            # runtime.close() is idempotent — safe even if RetryClient already closed the session
             await self._runtime.close()
         self._connected = False
         logger.info("ApiDestinationHandler disconnected")

--- a/src/destination/connectors/api.py
+++ b/src/destination/connectors/api.py
@@ -4,7 +4,6 @@ This handler sends records to REST API endpoints with support for
 rate limiting, retries, and different batch modes.
 """
 
-import base64
 import json
 import logging
 from typing import Any, Dict, List, Optional
@@ -18,6 +17,7 @@ from ...grpc.generated.analitiq.v1 import (
     Cursor,
     SchemaMessage,
 )
+from ...shared.connection_runtime import ConnectionRuntime
 from ...shared.rate_limiter import RateLimiter
 
 
@@ -56,13 +56,13 @@ class ApiDestinationHandler(BaseDestinationHandler):
 
     def __init__(self) -> None:
         """Initialize the API handler."""
+        self._runtime: ConnectionRuntime | None = None
         self._session: RetryClient | None = None
         self._config: Dict[str, Any] = {}
         self._connected: bool = False
 
         # Connection settings
         self._base_url: str = ""
-        self._headers: Dict[str, str] = {}
         self._timeout: int = 30
 
         # Rate limiter
@@ -99,97 +99,42 @@ class ApiDestinationHandler(BaseDestinationHandler):
         """APIs support bulk mode."""
         return True
 
-    async def connect(self, connection_config: Dict[str, Any]) -> None:
+    async def connect(self, runtime: ConnectionRuntime) -> None:
         """
-        Establish connection to the API.
+        Establish connection to the API using ConnectionRuntime.
 
         Args:
-            connection_config: Connection configuration
+            runtime: ConnectionRuntime with enriched config
         """
-        self._config = connection_config
-        params = connection_config.get("parameters", {})
+        self._runtime = runtime
+        await runtime.materialize()
+        self._base_url = runtime.base_url
+        self._rate_limiter = runtime.rate_limiter
+        self._max_retries = runtime.raw_config.get("max_retries", 3)
 
-        # Extract connection settings
-        self._base_url = connection_config.get("host", "").rstrip("/")
-        if not self._base_url:
-            raise ValueError("API destination requires 'host' in configuration")
-
-        self._headers = dict(params.get("headers", {}))
-        self._timeout = params.get("timeout", 30)
-        self._max_retries = connection_config.get("max_retries", 3)
-
-        # Setup authentication if provided
-        auth_config = connection_config.get("auth")
-        if auth_config:
-            self._setup_auth(auth_config)
-
-        # Setup rate limiting
-        rate_limit = params.get("rate_limit")
-        if rate_limit:
-            self._rate_limiter = RateLimiter(
-                max_requests=rate_limit.get("max_requests", 100),
-                time_window=rate_limit.get("time_window", 60),
-            )
-
-        # Create aiohttp session with retry support
-        timeout = aiohttp.ClientTimeout(total=self._timeout)
-        connector = aiohttp.TCPConnector(
-            limit=params.get("max_connections", 10),
-            limit_per_host=params.get("max_connections_per_host", 5),
-        )
-
-        # Configure retry: only retry on specific status codes
-        # 429 (rate limit), 500, 503, 504 get up to 3 attempts
-        # 502 and other 4xx errors are NOT retried
+        # Wrap plain session with retry (destination-specific)
         retry_options = ExponentialRetry(
             attempts=self._max_retries,
             statuses=self._retry_statuses,
         )
-
         self._session = RetryClient(
-            client_session=aiohttp.ClientSession(
-                timeout=timeout,
-                connector=connector,
-                headers=self._headers,
-            ),
+            client_session=runtime.session,
             retry_options=retry_options,
         )
 
         self._connected = True
         logger.info(f"ApiDestinationHandler connected to {self._base_url}")
 
-    def _setup_auth(self, auth_config: Dict[str, Any]) -> None:
-        """
-        Setup authentication headers.
-
-        Args:
-            auth_config: Authentication configuration
-        """
-        auth_type = auth_config.get("type", "").lower()
-
-        if auth_type == "bearer_token" or auth_type == "bearer":
-            token = auth_config.get("token", "")
-            self._headers["Authorization"] = f"Bearer {token}"
-
-        elif auth_type == "api_key":
-            api_key = auth_config.get("api_key", "")
-            header_name = auth_config.get("header_name", "X-API-Key")
-            self._headers[header_name] = api_key
-
-        elif auth_type == "basic":
-            username = auth_config.get("username", "")
-            password = auth_config.get("password", "")
-            credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
-            self._headers["Authorization"] = f"Basic {credentials}"
-
-        logger.debug(f"Configured {auth_type} authentication")
-
     async def disconnect(self) -> None:
         """Close API connection."""
-        if self._session and self._connected:
+        if self._session:
+            # RetryClient.close() does NOT close the underlying session
             await self._session.close()
-            self._connected = False
-            logger.info("ApiDestinationHandler disconnected")
+        if self._runtime:
+            # Close the underlying plain session owned by the runtime
+            await self._runtime.close()
+        self._connected = False
+        logger.info("ApiDestinationHandler disconnected")
 
     async def configure_schema(self, schema_msg: SchemaMessage) -> bool:
         """

--- a/src/destination/connectors/api.py
+++ b/src/destination/connectors/api.py
@@ -107,6 +107,7 @@ class ApiDestinationHandler(BaseDestinationHandler):
             runtime: ConnectionRuntime with enriched config
         """
         self._runtime = runtime
+        runtime.acquire()
         await runtime.materialize()
         self._base_url = runtime.base_url
         self._rate_limiter = runtime.rate_limiter

--- a/src/destination/connectors/database.py
+++ b/src/destination/connectors/database.py
@@ -36,7 +36,7 @@ from ...grpc.generated.analitiq.v1 import (
     Cursor,
     SchemaMessage,
 )
-from ...shared.database_utils import create_database_engine
+from ...shared.connection_runtime import ConnectionRuntime
 
 
 logger = logging.getLogger(__name__)
@@ -74,6 +74,7 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
 
     def __init__(self) -> None:
         """Initialize the database handler."""
+        self._runtime: ConnectionRuntime | None = None
         self._engine: AsyncEngine | None = None
         self._metadata: MetaData = MetaData()
         self._config: Dict[str, Any] = {}
@@ -114,26 +115,26 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
         """Bulk load support depends on database."""
         return False
 
-    async def connect(self, connection_config: Dict[str, Any]) -> None:
+    async def connect(self, runtime: ConnectionRuntime) -> None:
         """
-        Establish database connection using the shared engine factory.
+        Establish database connection using ConnectionRuntime.
 
         Args:
-            connection_config: Connection configuration
+            runtime: ConnectionRuntime with enriched config
         """
-        self._config = connection_config
-        self._engine, self._driver = await create_database_engine(
-            connection_config, require_port=False
-        )
+        self._runtime = runtime
+        await runtime.materialize(require_port=False)
+        self._engine = runtime.engine
+        self._driver = runtime.driver or ""
         self._connected = True
         logger.info("DatabaseDestinationHandler connected to %s", self._driver)
 
     async def disconnect(self) -> None:
         """Close database connection."""
-        if self._engine and self._connected:
-            await self._engine.dispose()
-            self._connected = False
-            logger.info("DatabaseDestinationHandler disconnected")
+        if self._runtime:
+            await self._runtime.close()
+        self._connected = False
+        logger.info("DatabaseDestinationHandler disconnected")
 
     async def configure_schema(self, schema_msg: SchemaMessage) -> bool:
         """

--- a/src/destination/connectors/database.py
+++ b/src/destination/connectors/database.py
@@ -123,6 +123,7 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
             runtime: ConnectionRuntime with enriched config
         """
         self._runtime = runtime
+        runtime.acquire()
         try:
             await runtime.materialize(require_port=False)
         except Exception as e:

--- a/src/destination/connectors/database.py
+++ b/src/destination/connectors/database.py
@@ -123,7 +123,11 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
             runtime: ConnectionRuntime with enriched config
         """
         self._runtime = runtime
-        await runtime.materialize(require_port=False)
+        try:
+            await runtime.materialize(require_port=False)
+        except Exception as e:
+            logger.error(f"Database destination connection failed: {e}")
+            raise ConnectionError(f"Database connection failed: {e}") from e
         self._engine = runtime.engine
         self._driver = runtime.driver or ""
         self._connected = True

--- a/src/destination/connectors/file.py
+++ b/src/destination/connectors/file.py
@@ -80,6 +80,7 @@ class FileDestinationHandler(BaseDestinationHandler):
         Args:
             runtime: ConnectionRuntime with enriched config
         """
+        runtime.acquire()
         await runtime.materialize()
         connection_config = runtime.resolved_config
         self._config = connection_config

--- a/src/destination/connectors/file.py
+++ b/src/destination/connectors/file.py
@@ -44,6 +44,7 @@ class FileDestinationHandler(BaseDestinationHandler):
 
     def __init__(self) -> None:
         """Initialize the file handler."""
+        self._runtime: ConnectionRuntime | None = None
         self._storage: BaseStorageBackend | None = None
         self._formatter: BaseFormatter | None = None
         self._manifest: ManifestTracker | None = None
@@ -122,7 +123,7 @@ class FileDestinationHandler(BaseDestinationHandler):
         """Disconnect the file handler."""
         if self._storage and self._connected:
             await self._storage.disconnect()
-        if hasattr(self, '_runtime') and self._runtime:
+        if self._runtime:
             await self._runtime.close()
         self._connected = False
         logger.info("FileDestinationHandler disconnected")

--- a/src/destination/connectors/file.py
+++ b/src/destination/connectors/file.py
@@ -17,6 +17,7 @@ from ...grpc.generated.analitiq.v1 import (
     Cursor,
     SchemaMessage,
 )
+from ...shared.connection_runtime import ConnectionRuntime
 
 
 logger = logging.getLogger(__name__)
@@ -71,15 +72,18 @@ class FileDestinationHandler(BaseDestinationHandler):
         """File destinations support bulk writes."""
         return True
 
-    async def connect(self, connection_config: Dict[str, Any]) -> None:
+    async def connect(self, runtime: ConnectionRuntime) -> None:
         """
         Initialize the file handler with configuration.
 
         Args:
-            connection_config: Configuration dictionary
+            runtime: ConnectionRuntime with enriched config
         """
+        await runtime.materialize()
+        connection_config = runtime.resolved_config
         self._config = connection_config
         self._connector_type = connection_config.get("connector_type", "file")
+        self._runtime = runtime
 
         # Determine storage backend type
         storage_type = "local" if self._connector_type == "file" else self._connector_type
@@ -118,8 +122,10 @@ class FileDestinationHandler(BaseDestinationHandler):
         """Disconnect the file handler."""
         if self._storage and self._connected:
             await self._storage.disconnect()
-            self._connected = False
-            logger.info("FileDestinationHandler disconnected")
+        if hasattr(self, '_runtime') and self._runtime:
+            await self._runtime.close()
+        self._connected = False
+        logger.info("FileDestinationHandler disconnected")
 
     async def configure_schema(self, schema_msg: SchemaMessage) -> bool:
         """

--- a/src/destination/connectors/stream.py
+++ b/src/destination/connectors/stream.py
@@ -37,6 +37,7 @@ class StreamDestinationHandler(BaseDestinationHandler):
 
     def __init__(self) -> None:
         """Initialize the stream handler."""
+        self._runtime: ConnectionRuntime | None = None
         self._formatter: BaseFormatter | None = None
         self._config: Dict[str, Any] = {}
         self._connected: bool = False
@@ -94,7 +95,7 @@ class StreamDestinationHandler(BaseDestinationHandler):
         """
         if self._connected:
             sys.stdout.flush()
-        if hasattr(self, '_runtime') and self._runtime:
+        if self._runtime:
             await self._runtime.close()
         self._connected = False
         logger.info("StreamDestinationHandler disconnected")

--- a/src/destination/connectors/stream.py
+++ b/src/destination/connectors/stream.py
@@ -70,6 +70,7 @@ class StreamDestinationHandler(BaseDestinationHandler):
             runtime: ConnectionRuntime with enriched config
         """
         self._runtime = runtime
+        runtime.acquire()
         await runtime.materialize()
         connection_config = runtime.resolved_config
         self._config = connection_config

--- a/src/destination/connectors/stream.py
+++ b/src/destination/connectors/stream.py
@@ -16,6 +16,7 @@ from ...grpc.generated.analitiq.v1 import (
     Cursor,
     SchemaMessage,
 )
+from ...shared.connection_runtime import ConnectionRuntime
 
 
 logger = logging.getLogger(__name__)
@@ -60,15 +61,16 @@ class StreamDestinationHandler(BaseDestinationHandler):
         """Stdout does not support bulk load."""
         return False
 
-    async def connect(self, connection_config: Dict[str, Any]) -> None:
+    async def connect(self, runtime: ConnectionRuntime) -> None:
         """
         Initialize the stream handler with configuration.
 
         Args:
-            connection_config: Configuration dictionary with optional keys:
-                - file_format: Output format (jsonl, csv). Default: jsonl
-                - formatter_config: Format-specific configuration
+            runtime: ConnectionRuntime with enriched config
         """
+        self._runtime = runtime
+        await runtime.materialize()
+        connection_config = runtime.resolved_config
         self._config = connection_config
 
         # Get format from config, default to jsonl
@@ -92,8 +94,10 @@ class StreamDestinationHandler(BaseDestinationHandler):
         """
         if self._connected:
             sys.stdout.flush()
-            self._connected = False
-            logger.info("StreamDestinationHandler disconnected")
+        if hasattr(self, '_runtime') and self._runtime:
+            await self._runtime.close()
+        self._connected = False
+        logger.info("StreamDestinationHandler disconnected")
 
     async def configure_schema(self, schema_msg: SchemaMessage) -> bool:
         """

--- a/src/engine/engine.py
+++ b/src/engine/engine.py
@@ -249,6 +249,11 @@ class StreamingEngine:
 
             # Connect source connector using runtime
             runtime = merged_src_config.get("_runtime")
+            if not runtime:
+                raise StreamConfigurationError(
+                    "Missing _runtime in source config",
+                    stream_id=stream_id,
+                )
             await source_connector.connect(runtime)
 
             # Get current run_id from centralized source

--- a/src/engine/engine.py
+++ b/src/engine/engine.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, AsyncIterator, Tuple
 
 from ..source.connectors.base import BaseConnector
-from ..shared.connector_utils import get_connector_type_from_list
+from ..shared.connection_runtime import ConnectionRuntime
 from ..shared.run_id import get_or_generate_run_id
 from ..state.circuit_breaker import CircuitBreaker
 from ..state.dead_letter_queue import DeadLetterQueue
@@ -111,8 +111,6 @@ class StreamingEngine:
         # Stage configurations
         self.stage_configs = PipelineStagesConfig()
 
-        # Connectors array for connector_type lookup (populated by stream_data)
-        self._connectors: List[Dict[str, Any]] = []
 
     async def stream_data(self, pipeline_config: Dict[str, Any]) -> None:
         """Process all streams concurrently with state management."""
@@ -120,9 +118,6 @@ class StreamingEngine:
         pipeline_id = pipeline_config["pipeline_id"]
         streams = pipeline_config.get("streams", {})
 
-        # Store connectors for connector_type lookup
-        self._connectors = pipeline_config.get("connectors", [])
-        
         if not streams:
             raise ConfigurationError("No streams configured in pipeline")
 
@@ -252,15 +247,9 @@ class StreamingEngine:
             stream_dlq_path = f"{self.dlq.dlq_path}/{stream_id}"
             stream_dlq = DeadLetterQueue(stream_dlq_path)
 
-            # Resolve source connection config (expand ${placeholder} secrets)
-            connection_wrapper = merged_src_config.get("_connection_wrapper")
-            if connection_wrapper is not None:
-                src_connection_config = await connection_wrapper.resolve()
-            else:
-                src_connection_config = merged_src_config.get("_connection", merged_src_config)
-
-            # Connect to source
-            await source_connector.connect(src_connection_config)
+            # Connect source connector using runtime
+            runtime = merged_src_config.get("_runtime")
+            await source_connector.connect(runtime)
 
             # Get current run_id from centralized source
             run_id = self.state_manager.current_run_id or get_or_generate_run_id()
@@ -735,7 +724,20 @@ class StreamingEngine:
 
     def _create_source_connector(self, config: Dict[str, Any]) -> BaseConnector:
         """Create source connector based on configuration."""
-        return self._get_connector(config)
+        runtime = config.get("_runtime")
+        if not runtime:
+            raise ValueError("Missing _runtime in source config")
+
+        connector_type = runtime.connector_type
+
+        if connector_type == "api":
+            from ..source.connectors.api import APIConnector
+            return APIConnector()
+        elif connector_type == "database":
+            from ..source.connectors.database import DatabaseConnector
+            return DatabaseConnector()
+        else:
+            raise ValueError(f"Unknown connector_type '{connector_type}'")
 
     def _create_pipeline_stages(
         self,
@@ -821,47 +823,6 @@ class StreamingEngine:
             max_message_size=max_message_size,
         )
 
-    def _get_connector(self, config: Dict[str, Any]) -> BaseConnector:
-        """Get appropriate connector based on configuration.
-
-        Looks up connector_type from the connectors array using connector_id
-        from the connection configuration.
-
-        Args:
-            config: Source configuration containing _connection with connector_id
-
-        Returns:
-            Appropriate connector instance (APIConnector or DatabaseConnector)
-
-        Raises:
-            ValueError: If connector_id is missing or connector_type cannot be determined
-        """
-        # Get connection config (stored under _connection key by pipeline_config_prep)
-        connection_config = config.get("_connection", config)
-
-        # Get connector_id from connection config
-        connector_id = connection_config.get("connector_id")
-        if not connector_id:
-            raise ValueError(
-                "Connection configuration is missing 'connector_id'. "
-                "Cannot determine connector type."
-            )
-
-        # Look up connector_type from connectors array using shared utility
-        connectors = getattr(self, "_connectors", [])
-        connector_type = get_connector_type_from_list(connectors, connector_id)
-
-        if connector_type == "api":
-            from ..source.connectors.api import APIConnector
-            return APIConnector()
-        elif connector_type == "database":
-            from ..source.connectors.database import DatabaseConnector
-            return DatabaseConnector()
-        else:
-            raise ValueError(
-                f"Unknown connector_type '{connector_type}' for connector_id '{connector_id}'. "
-                f"Expected 'api' or 'database'."
-            )
 
     def _get_stream_name(self, config: Dict[str, Any]) -> str:
         """Generate stream name for state management."""

--- a/src/engine/pipeline.py
+++ b/src/engine/pipeline.py
@@ -171,7 +171,7 @@ class Pipeline:
             if connection_id and connection_id in self.resolved_connections:
                 runtime = self.resolved_connections[connection_id]
                 if isinstance(runtime, ConnectionRuntime):
-                    result = runtime.raw_config.copy()
+                    result = runtime.raw_config
                     result["_runtime"] = runtime
                     return result
                 elif isinstance(runtime, dict):

--- a/src/engine/pipeline.py
+++ b/src/engine/pipeline.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 from pydantic import ValidationError
 
 from .engine import StreamingEngine
-from .pipeline_config_prep import ResolvedConnection, _get_connection_uuid
+from .pipeline_config_prep import _get_connection_uuid
 
 from ..shared.run_id import get_or_generate_run_id
 from ..state.log_storage import LogStorageSettings, create_log_handler
@@ -19,7 +19,7 @@ from ..models.enriched import (
     EnrichedAPIConfig,
     EnrichedDatabaseConfig,
 )
-from ..shared.connector_utils import find_connector
+from ..shared.connection_runtime import ConnectionRuntime
 
 logger = logging.getLogger(__name__)
 
@@ -169,13 +169,13 @@ class Pipeline:
         def get_connection_config(connection_ref: str) -> Dict[str, Any]:
             connection_id = _get_connection_uuid(connections, connection_ref)
             if connection_id and connection_id in self.resolved_connections:
-                conn = self.resolved_connections[connection_id]
-                if isinstance(conn, ResolvedConnection):
-                    result = conn.config.copy()
-                    result["_connection_wrapper"] = conn.connection_config_wrapper
+                runtime = self.resolved_connections[connection_id]
+                if isinstance(runtime, ConnectionRuntime):
+                    result = runtime.raw_config.copy()
+                    result["_runtime"] = runtime
                     return result
-                elif isinstance(conn, dict):
-                    return conn.copy()
+                elif isinstance(runtime, dict):
+                    return runtime.copy()
             return {}
 
         # Helper to get resolved endpoint config by endpoint_id
@@ -215,13 +215,11 @@ class Pipeline:
             source_endpoint = get_endpoint_config(source["endpoint_id"])
             dest_endpoint = get_endpoint_config(dest["endpoint_id"])
 
-            # Look up connector metadata for source and destination
-            source_connector_id = source_conn.get("connector_id")
-            dest_connector_id = dest_conn.get("connector_id")
-            source_connector = find_connector(self.connectors, source_connector_id) if source_connector_id and self.connectors else None
-            dest_connector = find_connector(self.connectors, dest_connector_id) if dest_connector_id and self.connectors else None
-            source_connector_type = source_connector.get("connector_type") if source_connector else None
-            dest_connector_type = dest_connector.get("connector_type") if dest_connector else None
+            # Read connector metadata from runtime
+            source_runtime = source_conn.get("_runtime")
+            dest_runtime = dest_conn.get("_runtime")
+            source_connector_type = source_runtime.connector_type if source_runtime else None
+            dest_connector_type = dest_runtime.connector_type if dest_runtime else None
 
             # Source replication config
             replication = source.get("replication", {})
@@ -232,8 +230,8 @@ class Pipeline:
                 "host": source_conn.get("host"),
                 "parameters": source_conn.get("parameters", {}),
                 "connector_type": source_connector_type,
-                "driver": source_connector.get("driver") if source_connector else None,
-                "_connection_wrapper": source_conn.get("_connection_wrapper"),
+                "driver": source_runtime.driver if source_runtime else None,
+                "_runtime": source_runtime,
                 **source_endpoint,
                 "endpoint_id": source["endpoint_id"],
                 "connection_ref": source["connection_ref"],
@@ -253,8 +251,8 @@ class Pipeline:
                 "host": dest_conn.get("host"),
                 "parameters": dest_conn.get("parameters", {}),
                 "connector_type": dest_connector_type,
-                "driver": dest_connector.get("driver") if dest_connector else None,
-                "_connection_wrapper": dest_conn.get("_connection_wrapper"),
+                "driver": dest_runtime.driver if dest_runtime else None,
+                "_runtime": dest_runtime,
                 **dest_endpoint,
                 "endpoint_id": dest["endpoint_id"],
                 "connection_ref": dest["connection_ref"],

--- a/src/engine/pipeline.py
+++ b/src/engine/pipeline.py
@@ -168,15 +168,24 @@ class Pipeline:
         # Helper to get resolved connection config by reference
         def get_connection_config(connection_ref: str) -> Dict[str, Any]:
             connection_id = _get_connection_uuid(connections, connection_ref)
-            if connection_id and connection_id in self.resolved_connections:
-                runtime = self.resolved_connections[connection_id]
-                if isinstance(runtime, ConnectionRuntime):
-                    result = runtime.raw_config
-                    result["_runtime"] = runtime
-                    return result
-                elif isinstance(runtime, dict):
-                    return runtime.copy()
-            return {}
+            if not connection_id:
+                raise ValueError(
+                    f"Connection reference '{connection_ref}' not found in pipeline connections"
+                )
+            if connection_id not in self.resolved_connections:
+                raise ValueError(
+                    f"Connection '{connection_id}' (ref='{connection_ref}') was not resolved"
+                )
+            runtime = self.resolved_connections[connection_id]
+            if isinstance(runtime, ConnectionRuntime):
+                result = runtime.raw_config
+                result["_runtime"] = runtime
+                return result
+            elif isinstance(runtime, dict):
+                return runtime.copy()
+            raise ValueError(
+                f"Unexpected connection type for '{connection_id}': {type(runtime)}"
+            )
 
         # Helper to get resolved endpoint config by endpoint_id
         def get_endpoint_config(endpoint_id: str) -> Dict[str, Any]:

--- a/src/engine/pipeline_config_prep.py
+++ b/src/engine/pipeline_config_prep.py
@@ -52,45 +52,15 @@ def _get_connection_uuid(connections: Dict[str, Any], alias: str) -> Optional[st
     return None
 from src.secrets import (
     SecretsResolver,
-    ConnectionConfig,
     LocalFileSecretsResolver,
     InMemorySecretsResolver,
     SecretNotFoundError,
 )
+from src.shared.connection_runtime import ConnectionRuntime
 
 
 logger = logging.getLogger(__name__)
 
-
-
-class ResolvedConnection:
-    """
-    Container for a resolved connection configuration.
-
-    Secrets are resolved lazily via the ConnectionConfig wrapper
-    when resolve_config() is called.
-    """
-
-    def __init__(
-        self,
-        connection_id: str,
-        connection_type: str,
-        config: Dict[str, Any],
-        connection_config_wrapper: ConnectionConfig,
-    ):
-        self.connection_id = connection_id
-        self.connection_type = connection_type  # "api" or "database"
-        self.config = config
-        self.connection_config_wrapper = connection_config_wrapper
-
-    async def resolve_config(self) -> Dict[str, Any]:
-        """
-        Resolve secrets and return fully-expanded configuration.
-
-        Returns:
-            Fully resolved configuration dictionary
-        """
-        return await self.connection_config_wrapper.resolve()
 
 
 class PipelineConfigPrep:
@@ -128,7 +98,7 @@ class PipelineConfigPrep:
         self._consolidated_config: Optional[Dict[str, Any]] = None
 
         # Cache for resolved connections and endpoints
-        self._resolved_connections: Dict[str, ResolvedConnection] = {}
+        self._resolved_connections: Dict[str, ConnectionRuntime] = {}
         self._resolved_endpoints: Dict[str, Dict[str, Any]] = {}
 
         # Secrets resolver for late-binding (initialized lazily)
@@ -424,29 +394,27 @@ class PipelineConfigPrep:
         connection_ref: str,
         connection_id: str,
         org_id: str = ""
-    ) -> ResolvedConnection:
+    ) -> ConnectionRuntime:
         """
         Resolve a connection by its ID.
 
-        Loads connection config from connections/{connection_id}.json,
-        expands secrets from .secrets/{connection_id}.json.
+        Creates a ConnectionRuntime with enriched metadata (connector_type,
+        driver baked in). Secrets are resolved lazily via materialize().
 
         Args:
             connection_ref: Reference alias from pipeline (e.g., "conn_1")
-            connection_id: Connection identifier (filename without .json)
-            org_id: Org ID (for logging and late-binding resolver)
+            connection_id: Connection identifier
+            org_id: Org ID (for late-binding resolver)
 
         Returns:
-            ResolvedConnection object with expanded configuration
+            ConnectionRuntime object
         """
         cache_key = f"id:{connection_id}"
         if cache_key in self._resolved_connections:
             return self._resolved_connections[cache_key]
 
-        # Load connection config from connections directory
         config = self._load_connection_config(connection_id)
 
-        # Get connector and determine connection type
         connector = self.get_connector_for_connection(config, connection_id)
         connection_type = connector.get("connector_type")
 
@@ -456,30 +424,25 @@ class PipelineConfigPrep:
                 f"Expected one of: {sorted(self.VALID_CONNECTOR_TYPES)}"
             )
 
-        # Normalize database connections (adds driver from connector)
         if connection_type == "database":
             config = self._normalize_database_connection(config, connector)
 
         # Store secrets directory for the resolver
         self._secrets_dir = self._paths["secrets"]
 
-        config_wrapper = ConnectionConfig(
+        runtime = ConnectionRuntime(
             raw_config=config,
             connection_id=connection_id,
+            connector_type=connection_type,
+            driver=connector.get("driver") if connection_type == "database" else None,
             resolver=self.secrets_resolver,
             org_id=org_id or None,
         )
 
-        resolved = ResolvedConnection(
-            connection_ref,
-            connection_type,
-            config,
-            connection_config_wrapper=config_wrapper,
-        )
-        self._resolved_connections[cache_key] = resolved
+        self._resolved_connections[cache_key] = runtime
 
         logger.info(f"Resolved connection: {connection_ref} -> {connection_id}")
-        return resolved
+        return runtime
 
     # =========================================================================
     # Endpoint Loading Methods (from consolidated config)
@@ -685,8 +648,7 @@ class PipelineConfigPrep:
 
         # Build enriched source config
         source_data = raw_stream["source"].copy()
-        source_data["_connection"] = source_connection.config
-        source_data["_connection_wrapper"] = source_connection.connection_config_wrapper
+        source_data["_runtime"] = source_connection
         source_data["_endpoint"] = source_endpoint
 
         # Resolve destinations
@@ -711,7 +673,7 @@ class PipelineConfigPrep:
             dest_endpoint = self._resolve_endpoint_flexible(dest)
 
             dest_data = dest.copy()
-            dest_data["_connection"] = dest_connection.config
+            dest_data["_runtime"] = dest_connection
             dest_data["_endpoint"] = dest_endpoint
             destinations_data.append(dest_data)
 
@@ -905,7 +867,7 @@ class PipelineConfigPrep:
     def create_config(self) -> Tuple[
         Dict[str, Any],
         List[Dict[str, Any]],
-        Dict[str, "ResolvedConnection"],
+        Dict[str, "ConnectionRuntime"],
         Dict[str, Dict[str, Any]],
         List[Dict[str, Any]],
     ]:
@@ -913,10 +875,9 @@ class PipelineConfigPrep:
         Load and return validated pipeline and stream configurations.
 
         Returns:
-            Tuple of (pipeline_config dict, list of stream_config dicts, resolved_connections dict,
-                      resolved_endpoints dict, connectors list)
-            - resolved_connections maps connection_id to ResolvedConnection objects
-              (use await resolved.resolve_config() to get fully-expanded config)
+            Tuple of (pipeline_config, stream_configs, resolved_connections,
+                      resolved_endpoints, connectors)
+            - resolved_connections maps connection_id to ConnectionRuntime objects
             - resolved_endpoints maps endpoint_id to its resolved config dict
             - connectors is the list of connector definitions from consolidated config
         """
@@ -957,11 +918,12 @@ class PipelineConfigPrep:
             )
         logger.debug(f"Pipelines directory validated: {pipelines_path}")
 
-    def get_resolved_connection(self, connection_ref: str, connections_map: Dict[str, str]) -> ResolvedConnection:
+    def get_resolved_connection(self, connection_ref: str, connections_map: Dict[str, str]) -> ConnectionRuntime:
         """Get a resolved connection by its reference alias."""
         connection_id = connections_map.get(connection_ref)
         if not connection_id:
             raise ValueError(f"Unknown connection reference: {connection_ref}")
-        if connection_id not in self._resolved_connections:
+        cache_key = f"id:{connection_id}"
+        if cache_key not in self._resolved_connections:
             raise ValueError(f"Connection not resolved: {connection_id}")
-        return self._resolved_connections[connection_id]
+        return self._resolved_connections[cache_key]

--- a/src/main.py
+++ b/src/main.py
@@ -157,28 +157,19 @@ async def run_destination_mode() -> None:
 
     logger.info(f"Using destination index {destination_index}: alias={dest_alias}, connection_id={connection_id}")
 
-    # Get resolved connection config (with secrets already expanded)
+    # Get ConnectionRuntime for selected destination
     if connection_id not in resolved_connections:
         logger.error(f"Connection {connection_id} not found in resolved connections")
         sys.exit(1)
 
-    resolved_conn = resolved_connections[connection_id]
+    runtime = resolved_connections[connection_id]
 
-    connection_config = await resolved_conn.resolve_config()
-
-    # Look up connector metadata from connectors array using connector_id
-    connector = config_prep.get_connector_for_connection(connection_config, connection_id)
-    connector_type = connector.get("connector_type")
-
-    if connector_type == "database":
-        connection_config["driver"] = connector.get("driver")
-
-    logger.info(f"Connector type: {connector_type}")
+    logger.info(f"Connector type: {runtime.connector_type}")
     logger.info(f"gRPC port: {grpc_port}")
 
     # Create handler and start server
-    handler = get_handler(connector_type)
-    await handler.connect(connection_config)
+    handler = get_handler(runtime.connector_type)
+    await handler.connect(runtime)
 
     server = DestinationGRPCServer(handler, port=grpc_port)
 

--- a/src/shared/__init__.py
+++ b/src/shared/__init__.py
@@ -20,6 +20,7 @@ from .database_utils import (
     SSL_DIALECTS,
 )
 from .rate_limiter import RateLimiter
+from .connection_runtime import ConnectionRuntime
 from .connector_utils import (
     find_connector,
     get_connector_type_from_list,
@@ -45,6 +46,7 @@ __all__ = [
     "DIALECT_MAP",
     "SSL_DIALECTS",
     "RateLimiter",
+    "ConnectionRuntime",
     "find_connector",
     "get_connector_type_from_list",
     "get_run_id",

--- a/src/shared/connection_runtime.py
+++ b/src/shared/connection_runtime.py
@@ -1,0 +1,290 @@
+"""ConnectionRuntime — unified connection materialization.
+
+Single owner of connection lifecycle: enrich -> resolve -> materialize -> scrub.
+
+Created by PipelineConfigPrep with enriched config (connector_type, driver
+already baked in). Passed to connectors, which call materialize() to get
+a connected transport. Secrets are scrubbed from memory after materialization.
+
+Ownership: the connector/handler that receives this runtime owns it.
+It must call close() in its disconnect() method.
+"""
+
+import re
+import logging
+from typing import Any, Dict, Optional
+
+import aiohttp
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ..secrets.protocol import SecretsResolver
+from ..secrets.exceptions import PlaceholderExpansionError
+from .database_utils import create_database_engine
+from .rate_limiter import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+# Pattern for ${placeholder} syntax
+PLACEHOLDER_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+async def create_api_session(
+    config: Dict[str, Any],
+) -> tuple[aiohttp.ClientSession, str, Optional[RateLimiter]]:
+    """
+    Create an aiohttp session from resolved connection config.
+
+    Auth is resolved here from the resolved config, so headers contain
+    expanded secret values before the runtime scrubs the config.
+
+    Returns:
+        Tuple of (session, base_url, rate_limiter)
+    """
+    parameters = config.get("parameters", {})
+    base_url = config["host"].rstrip("/")
+    headers = dict(parameters.get("headers", {}))
+
+    # Resolve auth into headers (operates on resolved config)
+    auth_config = config.get("auth")
+    if auth_config:
+        auth_type = auth_config.get("type", "").lower()
+        if auth_type in ("bearer_token", "bearer"):
+            headers["Authorization"] = f"Bearer {auth_config.get('token', '')}"
+        elif auth_type == "api_key":
+            header_name = auth_config.get("header_name", "X-API-Key")
+            headers[header_name] = auth_config.get("api_key", "")
+        elif auth_type == "basic":
+            import base64
+            credentials = base64.b64encode(
+                f"{auth_config.get('username', '')}:{auth_config.get('password', '')}".encode()
+            ).decode()
+            headers["Authorization"] = f"Basic {credentials}"
+
+    timeout = aiohttp.ClientTimeout(total=parameters.get("timeout", 30))
+    connector = aiohttp.TCPConnector(
+        limit=parameters.get("max_connections", 100),
+        limit_per_host=parameters.get("max_connections_per_host", 10),
+    )
+
+    session = aiohttp.ClientSession(
+        timeout=timeout, connector=connector, headers=headers
+    )
+
+    rate_limiter = None
+    rate_limit = parameters.get("rate_limit")
+    if rate_limit:
+        rate_limiter = RateLimiter(
+            max_requests=rate_limit.get("max_requests", 100),
+            time_window=rate_limit.get("time_window", 60),
+        )
+
+    return session, base_url, rate_limiter
+
+
+class ConnectionRuntime:
+    """
+    Single owner of connection lifecycle.
+
+    Created by PipelineConfigPrep with enriched config (connector_type, driver
+    already baked in). Passed to connectors, which call materialize() to get
+    a connected transport. Secrets are scrubbed from memory after materialization.
+
+    Ownership: the connector/handler that receives this runtime owns it.
+    It must call close() in its disconnect() method.
+    """
+
+    def __init__(
+        self,
+        *,
+        raw_config: Dict[str, Any],
+        connection_id: str,
+        connector_type: str,
+        driver: Optional[str],
+        resolver: SecretsResolver,
+        org_id: Optional[str] = None,
+    ):
+        self._raw_config = raw_config
+        self._connection_id = connection_id
+        self._connector_type = connector_type
+        self._driver = driver
+        self._resolver = resolver
+        self._org_id = org_id
+
+        # Transport state — set by materialize()
+        self._materialized = False
+        self._engine: Optional[AsyncEngine] = None
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._base_url: Optional[str] = None
+        self._rate_limiter: Optional[RateLimiter] = None
+        self._resolved_config: Optional[Dict] = None
+
+        # Secret resolution internals
+        self._secrets: Optional[Dict[str, str]] = None
+
+    # --- Read-only metadata (available before materialize) ---
+
+    @property
+    def connector_type(self) -> str:
+        return self._connector_type
+
+    @property
+    def driver(self) -> Optional[str]:
+        return self._driver
+
+    @property
+    def connection_id(self) -> str:
+        return self._connection_id
+
+    @property
+    def raw_config(self) -> Dict[str, Any]:
+        return self._raw_config
+
+    # --- Materialization ---
+
+    async def materialize(self, *, require_port: bool = True) -> None:
+        """
+        Resolve secrets, create transport, scrub secrets.
+
+        Args:
+            require_port: For database connections, whether port is required.
+
+        Idempotent — second call is a no-op.
+        """
+        if self._materialized:
+            return
+
+        resolved = await self._resolve_secrets()
+
+        if self._connector_type == "database":
+            self._engine, _ = await create_database_engine(
+                resolved, require_port=require_port
+            )
+        elif self._connector_type == "api":
+            self._session, self._base_url, self._rate_limiter = (
+                await create_api_session(resolved)
+            )
+        else:
+            # file, s3, stdout — no transport, just resolved config
+            self._resolved_config = resolved
+
+        self._scrub_secrets()
+        self._materialized = True
+
+    # --- Transport accessors (available after materialize) ---
+
+    @property
+    def engine(self) -> AsyncEngine:
+        if not self._materialized or self._engine is None:
+            raise RuntimeError(
+                "engine not available: call materialize() first or wrong connector_type"
+            )
+        return self._engine
+
+    @property
+    def session(self) -> aiohttp.ClientSession:
+        if not self._materialized or self._session is None:
+            raise RuntimeError(
+                "session not available: call materialize() first or wrong connector_type"
+            )
+        return self._session
+
+    @property
+    def base_url(self) -> str:
+        if not self._materialized or self._base_url is None:
+            raise RuntimeError(
+                "base_url not available: call materialize() first or wrong connector_type"
+            )
+        return self._base_url
+
+    @property
+    def rate_limiter(self) -> Optional[RateLimiter]:
+        if not self._materialized:
+            raise RuntimeError("rate_limiter not available: call materialize() first")
+        return self._rate_limiter
+
+    @property
+    def resolved_config(self) -> Dict[str, Any]:
+        if not self._materialized or self._resolved_config is None:
+            raise RuntimeError(
+                "resolved_config not available: call materialize() first or wrong connector_type"
+            )
+        return self._resolved_config
+
+    # --- Teardown ---
+
+    async def close(self) -> None:
+        """Dispose transport resources. Safe to call multiple times."""
+        if self._engine:
+            await self._engine.dispose()
+            self._engine = None
+        if self._session:
+            await self._session.close()
+            self._session = None
+        self._materialized = False
+
+    # --- Private ---
+
+    async def _resolve_secrets(self) -> Dict[str, Any]:
+        """Resolve ${placeholder} values."""
+        if not self._has_placeholders(self._raw_config):
+            logger.debug(
+                f"No placeholders in connection {self._connection_id}, "
+                f"skipping secret resolution"
+            )
+            return self._raw_config.copy()
+
+        self._secrets = await self._resolver.resolve(
+            self._connection_id,
+            org_id=self._org_id,
+        )
+
+        resolved = self._expand_placeholders(self._raw_config, self._secrets)
+        logger.debug(f"Resolved secrets for connection: {self._connection_id}")
+        return resolved
+
+    def _expand_placeholders(
+        self,
+        value: Any,
+        secrets: Dict[str, str],
+    ) -> Any:
+        if isinstance(value, str):
+            return self._expand_string(value, secrets)
+        elif isinstance(value, dict):
+            return {k: self._expand_placeholders(v, secrets) for k, v in value.items()}
+        elif isinstance(value, list):
+            return [self._expand_placeholders(item, secrets) for item in value]
+        return value
+
+    def _expand_string(self, value: str, secrets: Dict[str, str]) -> str:
+        def replace_placeholder(match: re.Match) -> str:
+            key = match.group(1)
+            if key in secrets:
+                return str(secrets[key])
+            raise PlaceholderExpansionError(
+                placeholder=f"${{{key}}}",
+                connection_id=self._connection_id,
+                detail=f"Secret key '{key}' not found",
+            )
+
+        return PLACEHOLDER_PATTERN.sub(replace_placeholder, value)
+
+    def _has_placeholders(self, value: Any) -> bool:
+        if isinstance(value, str):
+            return bool(PLACEHOLDER_PATTERN.search(value))
+        elif isinstance(value, dict):
+            return any(self._has_placeholders(v) for v in value.values())
+        elif isinstance(value, list):
+            return any(self._has_placeholders(item) for item in value)
+        return False
+
+    def _scrub_secrets(self) -> None:
+        self._secrets = None
+        if self._connector_type in ("database", "api"):
+            self._resolved_config = None
+
+    def __repr__(self) -> str:
+        status = "materialized" if self._materialized else "pending"
+        return (
+            f"ConnectionRuntime({self._connection_id}, "
+            f"type={self._connector_type}, {status})"
+        )

--- a/src/shared/connection_runtime.py
+++ b/src/shared/connection_runtime.py
@@ -42,6 +42,8 @@ async def _create_api_session(
         Tuple of (session, base_url, rate_limiter)
     """
     parameters = config.get("parameters", {})
+    if "host" not in config or not config["host"]:
+        raise ValueError("API connection requires 'host' in configuration")
     base_url = config["host"].rstrip("/")
     headers = dict(parameters.get("headers", {}))
 
@@ -50,14 +52,24 @@ async def _create_api_session(
     if auth_config:
         auth_type = auth_config.get("type", "").lower()
         if auth_type in ("bearer_token", "bearer"):
-            headers["Authorization"] = f"Bearer {auth_config.get('token', '')}"
+            token = auth_config.get("token", "")
+            if not token:
+                raise ValueError("Auth type 'bearer' requires a non-empty 'token' field")
+            headers["Authorization"] = f"Bearer {token}"
         elif auth_type == "api_key":
             header_name = auth_config.get("header_name", "X-API-Key")
-            headers[header_name] = auth_config.get("api_key", "")
+            api_key = auth_config.get("api_key", "")
+            if not api_key:
+                raise ValueError("Auth type 'api_key' requires a non-empty 'api_key' field")
+            headers[header_name] = api_key
         elif auth_type == "basic":
             import base64
+            username = auth_config.get("username", "")
+            password = auth_config.get("password", "")
+            if not username:
+                raise ValueError("Auth type 'basic' requires a non-empty 'username' field")
             credentials = base64.b64encode(
-                f"{auth_config.get('username', '')}:{auth_config.get('password', '')}".encode()
+                f"{username}:{password}".encode()
             ).decode()
             headers["Authorization"] = f"Basic {credentials}"
         else:
@@ -239,12 +251,21 @@ class ConnectionRuntime:
         """
         try:
             if self._engine:
-                await self._engine.dispose()
+                try:
+                    await self._engine.dispose()
+                except Exception as e:
+                    logger.error(f"Failed to dispose engine for {self._connection_id}: {e}")
                 self._engine = None
         finally:
             if self._session:
-                await self._session.close()
+                try:
+                    await self._session.close()
+                except Exception as e:
+                    logger.error(f"Failed to close session for {self._connection_id}: {e}")
                 self._session = None
+            self._base_url = None
+            self._rate_limiter = None
+            self._resolved_config = None
             self._materialized = False
 
     # --- Private ---

--- a/src/shared/connection_runtime.py
+++ b/src/shared/connection_runtime.py
@@ -3,8 +3,9 @@
 Constructed by PipelineConfigPrep with enriched config (connector_type, driver
 already baked in). Internal lifecycle: resolve secrets -> create transport -> scrub.
 
-Ownership: the connector/handler that receives this runtime owns it.
-It must call close() in its disconnect() method.
+Shared ownership via reference counting: each consumer calls acquire() on
+connect and close() on disconnect. Transport is disposed only when the last
+consumer releases.
 """
 
 import copy
@@ -100,15 +101,14 @@ async def _create_api_session(
 
 class ConnectionRuntime:
     """
-    Single owner of connection lifecycle.
+    Shared-ownership connection lifecycle with reference counting.
 
     Constructed by PipelineConfigPrep with enriched config (connector_type,
-    driver already baked in). Passed to connectors, which call materialize()
-    to get a connected transport. Secrets are scrubbed from memory after
-    materialization.
+    driver already baked in). Multiple connectors may share the same instance
+    when streams reference the same connection_id.
 
-    Ownership: the connector/handler that receives this runtime owns it.
-    It must call close() in its disconnect() method.
+    Each consumer calls acquire() on connect and close() on disconnect.
+    Transport resources are only disposed when the last consumer releases.
     """
 
     def __init__(
@@ -141,6 +141,9 @@ class ConnectionRuntime:
         self._base_url: Optional[str] = None
         self._rate_limiter: Optional[RateLimiter] = None
         self._resolved_config: Optional[Dict] = None
+
+        # Reference counting for shared ownership across streams
+        self._ref_count = 0
 
         # Secret resolution internals
         self._secrets: Optional[Dict[str, str]] = None
@@ -240,15 +243,38 @@ class ConnectionRuntime:
             )
         return self._resolved_config
 
+    # --- Reference counting ---
+
+    def acquire(self) -> None:
+        """Register a consumer of this runtime. Call before using transport."""
+        self._ref_count += 1
+        logger.debug(
+            f"Runtime {self._connection_id} acquired (ref_count={self._ref_count})"
+        )
+
+    async def release(self) -> None:
+        """Alias for close() — decrement ref count and dispose if last."""
+        await self.close()
+
     # --- Teardown ---
 
     async def close(self) -> None:
         """
-        Dispose transport resources. Safe to call multiple times.
+        Decrement ref count; dispose transport when last consumer releases.
 
-        Resets materialization state, allowing materialize() to be called
-        again if reconnection is needed.
+        Safe to call multiple times. When ref count reaches zero the
+        underlying engine/session is disposed and materialization state is
+        reset.
         """
+        self._ref_count = max(0, self._ref_count - 1)
+        if self._ref_count > 0:
+            logger.debug(
+                f"Runtime {self._connection_id} released but still in use "
+                f"(ref_count={self._ref_count})"
+            )
+            return
+
+        logger.debug(f"Runtime {self._connection_id} closing (last reference)")
         try:
             if self._engine:
                 try:

--- a/src/shared/connection_runtime.py
+++ b/src/shared/connection_runtime.py
@@ -1,15 +1,13 @@
 """ConnectionRuntime — unified connection materialization.
 
-Single owner of connection lifecycle: enrich -> resolve -> materialize -> scrub.
-
-Created by PipelineConfigPrep with enriched config (connector_type, driver
-already baked in). Passed to connectors, which call materialize() to get
-a connected transport. Secrets are scrubbed from memory after materialization.
+Constructed by PipelineConfigPrep with enriched config (connector_type, driver
+already baked in). Internal lifecycle: resolve secrets -> create transport -> scrub.
 
 Ownership: the connector/handler that receives this runtime owns it.
 It must call close() in its disconnect() method.
 """
 
+import copy
 import re
 import logging
 from typing import Any, Dict, Optional
@@ -27,15 +25,18 @@ logger = logging.getLogger(__name__)
 # Pattern for ${placeholder} syntax
 PLACEHOLDER_PATTERN = re.compile(r"\$\{([^}]+)\}")
 
+VALID_CONNECTOR_TYPES = frozenset({"database", "api", "file", "s3", "stdout"})
 
-async def create_api_session(
+
+async def _create_api_session(
     config: Dict[str, Any],
 ) -> tuple[aiohttp.ClientSession, str, Optional[RateLimiter]]:
     """
     Create an aiohttp session from resolved connection config.
 
-    Auth is resolved here from the resolved config, so headers contain
-    expanded secret values before the runtime scrubs the config.
+    Auth headers are built from the already-resolved config, so secret values
+    are baked into the session headers before the runtime scrubs the resolved
+    config from memory.
 
     Returns:
         Tuple of (session, base_url, rate_limiter)
@@ -59,6 +60,10 @@ async def create_api_session(
                 f"{auth_config.get('username', '')}:{auth_config.get('password', '')}".encode()
             ).decode()
             headers["Authorization"] = f"Basic {credentials}"
+        else:
+            logger.warning(
+                f"Unknown auth type '{auth_type}', skipping auth header setup"
+            )
 
     timeout = aiohttp.ClientTimeout(total=parameters.get("timeout", 30))
     connector = aiohttp.TCPConnector(
@@ -85,9 +90,10 @@ class ConnectionRuntime:
     """
     Single owner of connection lifecycle.
 
-    Created by PipelineConfigPrep with enriched config (connector_type, driver
-    already baked in). Passed to connectors, which call materialize() to get
-    a connected transport. Secrets are scrubbed from memory after materialization.
+    Constructed by PipelineConfigPrep with enriched config (connector_type,
+    driver already baked in). Passed to connectors, which call materialize()
+    to get a connected transport. Secrets are scrubbed from memory after
+    materialization.
 
     Ownership: the connector/handler that receives this runtime owns it.
     It must call close() in its disconnect() method.
@@ -103,6 +109,12 @@ class ConnectionRuntime:
         resolver: SecretsResolver,
         org_id: Optional[str] = None,
     ):
+        if connector_type not in VALID_CONNECTOR_TYPES:
+            raise ValueError(
+                f"Invalid connector_type: {connector_type!r}. "
+                f"Expected one of: {sorted(VALID_CONNECTOR_TYPES)}"
+            )
+
         self._raw_config = raw_config
         self._connection_id = connection_id
         self._connector_type = connector_type
@@ -137,7 +149,7 @@ class ConnectionRuntime:
 
     @property
     def raw_config(self) -> Dict[str, Any]:
-        return self._raw_config
+        return copy.deepcopy(self._raw_config)
 
     # --- Materialization ---
 
@@ -147,6 +159,7 @@ class ConnectionRuntime:
 
         Args:
             require_port: For database connections, whether port is required.
+                          Ignored for non-database connector types.
 
         Idempotent — second call is a no-op.
         """
@@ -155,17 +168,22 @@ class ConnectionRuntime:
 
         resolved = await self._resolve_secrets()
 
-        if self._connector_type == "database":
-            self._engine, _ = await create_database_engine(
-                resolved, require_port=require_port
-            )
-        elif self._connector_type == "api":
-            self._session, self._base_url, self._rate_limiter = (
-                await create_api_session(resolved)
-            )
-        else:
-            # file, s3, stdout — no transport, just resolved config
-            self._resolved_config = resolved
+        try:
+            if self._connector_type == "database":
+                self._engine, _ = await create_database_engine(
+                    resolved, require_port=require_port
+                )
+            elif self._connector_type == "api":
+                self._session, self._base_url, self._rate_limiter = (
+                    await _create_api_session(resolved)
+                )
+            else:
+                # file, s3, stdout — no transport, just resolved config
+                self._resolved_config = resolved
+        except Exception:
+            # Clean up secrets on failure — don't leave them in memory
+            self._scrub_secrets()
+            raise
 
         self._scrub_secrets()
         self._materialized = True
@@ -213,14 +231,21 @@ class ConnectionRuntime:
     # --- Teardown ---
 
     async def close(self) -> None:
-        """Dispose transport resources. Safe to call multiple times."""
-        if self._engine:
-            await self._engine.dispose()
-            self._engine = None
-        if self._session:
-            await self._session.close()
-            self._session = None
-        self._materialized = False
+        """
+        Dispose transport resources. Safe to call multiple times.
+
+        Resets materialization state, allowing materialize() to be called
+        again if reconnection is needed.
+        """
+        try:
+            if self._engine:
+                await self._engine.dispose()
+                self._engine = None
+        finally:
+            if self._session:
+                await self._session.close()
+                self._session = None
+            self._materialized = False
 
     # --- Private ---
 
@@ -231,7 +256,7 @@ class ConnectionRuntime:
                 f"No placeholders in connection {self._connection_id}, "
                 f"skipping secret resolution"
             )
-            return self._raw_config.copy()
+            return copy.deepcopy(self._raw_config)
 
         self._secrets = await self._resolver.resolve(
             self._connection_id,

--- a/src/source/connectors/api.py
+++ b/src/source/connectors/api.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 from urllib.parse import urljoin, urlencode
 
 from .base import BaseConnector, ConnectionError, ReadError, WriteError
+from ...shared.connection_runtime import ConnectionRuntime
 from ...state.state_manager import StateManager
 from ...models.state import StreamCursor, CursorField, StreamStats
 from ...shared.rate_limiter import RateLimiter
@@ -27,72 +28,34 @@ class APIConnector(BaseConnector):
 
     def __init__(self, name: str = "APIConnector"):
         super().__init__(name)
+        self._runtime: ConnectionRuntime | None = None
         self.session = None
         self.base_url = None
         self.headers = {}
         self.rate_limiter = None
 
-    async def connect(self, config: Dict[str, Any]):
-        """Establish connection to the API."""
+    async def connect(self, runtime: ConnectionRuntime):
+        """Establish connection to the API using ConnectionRuntime."""
         try:
-            import aiohttp
-            
-            parameters = config.get("parameters", {})
-
-            self.base_url = config["host"]
-            self.headers = parameters.get("headers", {})
-
-            # Create session with timeout and connection limits
-            timeout_seconds = parameters.get("timeout", 30)
-            max_connections = parameters.get("max_connections", 100)
-            max_connections_per_host = parameters.get("max_connections_per_host", 10)
-
-            timeout = aiohttp.ClientTimeout(total=timeout_seconds)
-            connector = aiohttp.TCPConnector(
-                limit=max_connections,
-                limit_per_host=max_connections_per_host,
-            )
-
-            self.session = aiohttp.ClientSession(
-                timeout=timeout, connector=connector, headers=self.headers
-            )
-
-            # Log connection configuration (mask sensitive values)
-            masked_headers = self._mask_sensitive_headers(self.headers)
-            logger.debug(f"API Connection configured:")
-            logger.debug(f"  Base URL: {self.base_url}")
-            logger.debug(f"  Headers: {masked_headers}")
-            logger.debug(f"  Timeout: {timeout_seconds}s")
-            logger.debug(f"  Max connections: {max_connections}")
-
-            # Set up rate limiting
-            rate_limit = parameters.get("rate_limit")
-            if rate_limit:
-                self.rate_limiter = RateLimiter(
-                    max_requests=rate_limit["max_requests"],
-                    time_window=rate_limit["time_window"],
-                )
-
+            self._runtime = runtime
+            await runtime.materialize()
+            self.session = runtime.session
+            self.base_url = runtime.base_url
+            self.rate_limiter = runtime.rate_limiter
             self.is_connected = True
             logger.debug(f"Connected to API: {self.base_url}")
 
-        except ImportError:
-            raise ConnectionError(
-                "aiohttp package not installed. Install with: pip install aiohttp"
-            )
         except Exception as e:
             logger.error(f"Failed to connect to API: {str(e)}")
             raise ConnectionError(f"API connection failed: {str(e)}")
 
-
     async def disconnect(self):
         """Close API connection."""
-        if self.session:
-            await self.session.close()
-            # Allow event loop to close underlying transport
+        if self._runtime:
+            await self._runtime.close()
             await asyncio.sleep(0.25)
-            self.session = None
-            self.is_connected = False
+        self.session = None
+        self.is_connected = False
 
     async def read_batches(
         self,

--- a/src/source/connectors/api.py
+++ b/src/source/connectors/api.py
@@ -39,6 +39,7 @@ class APIConnector(BaseConnector):
         """Establish connection to the API using ConnectionRuntime."""
         try:
             self._runtime = runtime
+            runtime.acquire()
             await runtime.materialize()
             self.session = runtime.session
             self.base_url = runtime.base_url

--- a/src/source/connectors/api.py
+++ b/src/source/connectors/api.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any, AsyncIterator, Dict, List, Optional
 from urllib.parse import urljoin, urlencode
@@ -177,9 +178,9 @@ class APIConnector(BaseConnector):
                             state_manager.save_stream_checkpoint(
                                 stream_name=stream_name,
                                 partition=partition,
-                                cursor=cursor.model_dump(mode='json'),
+                                cursor=asdict(cursor),
                                 hwm=cursor_value,
-                                stats=stats.model_dump(mode='json')
+                                stats=asdict(stats)
                             )
             else:
                 # Single request without pagination
@@ -239,9 +240,9 @@ class APIConnector(BaseConnector):
                         state_manager.save_stream_checkpoint(
                             stream_name=stream_name,
                             partition=partition,
-                            cursor=cursor.model_dump(mode='json'),
+                            cursor=asdict(cursor),
                             hwm=cursor_value,
-                            stats=stats.model_dump(mode='json')
+                            stats=asdict(stats)
                         )
 
         except Exception as e:

--- a/src/source/connectors/api.py
+++ b/src/source/connectors/api.py
@@ -47,7 +47,7 @@ class APIConnector(BaseConnector):
 
         except Exception as e:
             logger.error(f"Failed to connect to API: {str(e)}")
-            raise ConnectionError(f"API connection failed: {str(e)}")
+            raise ConnectionError(f"API connection failed: {str(e)}") from e
 
     async def disconnect(self):
         """Close API connection."""

--- a/src/source/connectors/base.py
+++ b/src/source/connectors/base.py
@@ -39,7 +39,7 @@ class BaseConnector(ABC):
         Establish connection to the data source.
 
         Args:
-            runtime: ConnectionRuntime with enriched config and transport factory
+            runtime: ConnectionRuntime that manages connection lifecycle
         """
         pass
 

--- a/src/source/connectors/base.py
+++ b/src/source/connectors/base.py
@@ -34,12 +34,12 @@ class BaseConnector(ABC):
         }
 
     @abstractmethod
-    async def connect(self, config: Dict[str, Any]):
+    async def connect(self, runtime: "ConnectionRuntime"):
         """
         Establish connection to the data source.
 
         Args:
-            config: Connection configuration
+            runtime: ConnectionRuntime with enriched config and transport factory
         """
         pass
 

--- a/src/source/connectors/database.py
+++ b/src/source/connectors/database.py
@@ -71,7 +71,7 @@ class DatabaseConnector(BaseConnector):
             logger.info("Connected to database via %s", self._driver)
         except Exception as e:
             logger.error("Failed to connect to database: %s", e)
-            raise ConnectionError(f"Database connection failed: {e}")
+            raise ConnectionError(f"Database connection failed: {e}") from e
 
     async def disconnect(self):
         """Close database connection."""

--- a/src/source/connectors/database.py
+++ b/src/source/connectors/database.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 from .base import BaseConnector, ConnectionError, ReadError, WriteError
+from ...shared.connection_runtime import ConnectionRuntime
 from ...shared.database_utils import (
-    create_database_engine,
     acquire_connection,
     convert_record_from_db,
 )
@@ -26,6 +26,7 @@ class DatabaseConnector(BaseConnector):
 
     def __init__(self, name: str = "DatabaseConnector"):
         super().__init__(name)
+        self._runtime: ConnectionRuntime | None = None
         self._engine = None
         self._driver: str = ""
         self.table_info_cache = {}
@@ -53,17 +54,18 @@ class DatabaseConnector(BaseConnector):
             table_name = endpoint
         return schema_name, table_name
 
-    async def connect(self, config: Dict[str, Any]):
+    async def connect(self, runtime: ConnectionRuntime):
         """
-        Establish connection to the database using the shared engine factory.
+        Establish connection to the database using ConnectionRuntime.
 
         Args:
-            config: Connection configuration with driver and credentials
+            runtime: ConnectionRuntime with enriched config
         """
         try:
-            self._engine, self._driver = await create_database_engine(
-                config, require_port=True
-            )
+            self._runtime = runtime
+            await runtime.materialize(require_port=True)
+            self._engine = runtime.engine
+            self._driver = runtime.driver or ""
             self.is_connected = True
             self._initialized = True
             logger.info("Connected to database via %s", self._driver)
@@ -73,9 +75,9 @@ class DatabaseConnector(BaseConnector):
 
     async def disconnect(self):
         """Close database connection."""
-        if self._engine:
-            await self._engine.dispose()
-            self._engine = None
+        if self._runtime:
+            await self._runtime.close()
+        self._engine = None
         self.is_connected = False
         self._initialized = False
         logger.info("Database connection closed")

--- a/src/source/connectors/database.py
+++ b/src/source/connectors/database.py
@@ -63,6 +63,7 @@ class DatabaseConnector(BaseConnector):
         """
         try:
             self._runtime = runtime
+            runtime.acquire()
             await runtime.materialize(require_port=True)
             self._engine = runtime.engine
             self._driver = runtime.driver or ""

--- a/src/state/state_storage.py
+++ b/src/state/state_storage.py
@@ -5,12 +5,24 @@ import logging
 import os
 import shutil
 from abc import ABC, abstractmethod
+from datetime import datetime, date
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
+
+
+class _StateEncoder(json.JSONEncoder):
+    """JSON encoder that handles known state types, raises on unexpected types."""
+
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        if isinstance(obj, date):
+            return obj.isoformat()
+        raise TypeError(f"State data contains non-serializable type: {type(obj).__name__}")
 
 
 class StateStorageSettings(BaseModel):
@@ -123,7 +135,7 @@ class LocalStateStorage(StateStorageBackend):
 
         try:
             with open(temp_file, "w") as f:
-                json.dump(data, f, indent=2, default=str)
+                json.dump(data, f, indent=2, cls=_StateEncoder)
             temp_file.replace(full_path)
             logger.debug(f"Wrote state to {full_path}")
         except Exception as e:
@@ -225,7 +237,7 @@ class S3StateStorage(StateStorageBackend):
 
         key = self._build_s3_key(path)
         try:
-            content = json.dumps(data, indent=2, default=str)
+            content = json.dumps(data, indent=2, cls=_StateEncoder)
             self.s3_client.put_object(
                 Bucket=self.bucket,
                 Key=key,

--- a/src/state/state_storage.py
+++ b/src/state/state_storage.py
@@ -123,7 +123,7 @@ class LocalStateStorage(StateStorageBackend):
 
         try:
             with open(temp_file, "w") as f:
-                json.dump(data, f, indent=2)
+                json.dump(data, f, indent=2, default=str)
             temp_file.replace(full_path)
             logger.debug(f"Wrote state to {full_path}")
         except Exception as e:
@@ -225,7 +225,7 @@ class S3StateStorage(StateStorageBackend):
 
         key = self._build_s3_key(path)
         try:
-            content = json.dumps(data, indent=2)
+            content = json.dumps(data, indent=2, default=str)
             self.s3_client.put_object(
                 Bucket=self.bucket,
                 Key=key,

--- a/tests/integration/test_api_connector.py
+++ b/tests/integration/test_api_connector.py
@@ -9,7 +9,20 @@ from aiohttp import ClientTimeout, TCPConnector, ClientSession
 
 from src.source.connectors.api import APIConnector, RateLimiter
 from src.source.connectors.base import ConnectionError, ReadError, WriteError
+from src.shared.connection_runtime import ConnectionRuntime
+from src.secrets.resolvers.memory import InMemorySecretsResolver
 from src.state.state_manager import StateManager
+
+
+def _make_api_runtime(config):
+    """Create a ConnectionRuntime for API tests."""
+    return ConnectionRuntime(
+        raw_config=config,
+        connector_type="api",
+        driver=None,
+        connection_id="test-conn",
+        resolver=InMemorySecretsResolver({}),
+    )
 
 
 @pytest.fixture
@@ -66,24 +79,24 @@ class TestConnection:
     @pytest.mark.asyncio
     async def test_connect_success(self, connector, valid_connection_config):
         """Test successful API connection."""
+        runtime = _make_api_runtime(valid_connection_config)
         with patch('aiohttp.ClientSession') as mock_session_cls, \
              patch('aiohttp.ClientTimeout') as mock_timeout_cls, \
              patch('aiohttp.TCPConnector') as mock_connector_cls:
-            
+
             mock_session = AsyncMock()
             mock_session_cls.return_value = mock_session
-            
-            await connector.connect(valid_connection_config)
-            
+
+            await connector.connect(runtime)
+
             assert connector.is_connected is True
             assert connector.base_url == "https://api.example.com"
-            assert connector.headers == {"Authorization": "Bearer token"}
             assert connector.session == mock_session
-            
+
             # Verify aiohttp components were configured correctly
             mock_timeout_cls.assert_called_once_with(total=30)
             mock_connector_cls.assert_called_once_with(limit=5, limit_per_host=2)
-    
+
     @pytest.mark.asyncio
     async def test_connect_with_rate_limit(self, connector):
         """Test connection with rate limiting configuration."""
@@ -97,41 +110,45 @@ class TestConnection:
                 "rate_limit": {"max_requests": 10, "time_window": 60},
             },
         }
-        
+        runtime = _make_api_runtime(config)
+
         with patch('aiohttp.ClientSession'), \
              patch('aiohttp.ClientTimeout'), \
              patch('aiohttp.TCPConnector'):
-            
-            await connector.connect(config)
-            
+
+            await connector.connect(runtime)
+
             assert connector.rate_limiter is not None
             assert connector.rate_limiter.max_requests == 10
             assert connector.rate_limiter.time_window == 60
-    
+
     @pytest.mark.asyncio
     async def test_connect_invalid_config(self, connector):
         """Test connection with invalid configuration."""
-        invalid_config = {"invalid": "config"}
-        
-        with pytest.raises(ConnectionError, match="Invalid API connection configuration"):
-            await connector.connect(invalid_config)
-    
+        runtime = _make_api_runtime({"invalid": "config"})
+
+        with pytest.raises(ConnectionError, match="API connection failed"):
+            await connector.connect(runtime)
+
     @pytest.mark.asyncio
-    async def test_connect_missing_aiohttp(self, connector, valid_connection_config):
-        """Test connection when aiohttp is not available."""
-        with patch('builtins.__import__', side_effect=ImportError):
-            with pytest.raises(ConnectionError, match="aiohttp package not installed"):
-                await connector.connect(valid_connection_config)
+    async def test_connect_missing_host(self, connector):
+        """Test connection with missing host."""
+        runtime = _make_api_runtime({"parameters": {}})
+
+        with pytest.raises(ConnectionError, match="API connection failed"):
+            await connector.connect(runtime)
     
     @pytest.mark.asyncio
     async def test_disconnect(self, connector, mock_session):
         """Test API disconnection."""
+        mock_runtime = AsyncMock()
+        connector._runtime = mock_runtime
         connector.session = mock_session
         connector.is_connected = True
-        
+
         await connector.disconnect()
-        
-        mock_session.close.assert_called_once()
+
+        mock_runtime.close.assert_called_once()
         assert connector.is_connected is False
     
     @pytest.mark.asyncio

--- a/tests/integration/test_config_payload_structure.py
+++ b/tests/integration/test_config_payload_structure.py
@@ -11,10 +11,10 @@ These tests verify that:
 """
 
 import pytest
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from src.engine.pipeline import Pipeline
-from src.engine.pipeline_config_prep import ResolvedConnection
+from src.shared.connection_runtime import ConnectionRuntime
 
 
 # --- Test UUIDs ---
@@ -44,7 +44,7 @@ API_DB_CONNECTORS = [
 
 
 def _wise_connection_config():
-    """Wise API connection config (compatible with APIConnectionConfig)."""
+    """Wise API connection config."""
     return {
         "connector_id": "api-connector",
         "connector_type": "api",
@@ -65,7 +65,7 @@ def _wise_connection_config():
 
 
 def _sevdesk_connection_config():
-    """SevDesk API connection config (compatible with APIConnectionConfig)."""
+    """SevDesk API connection config."""
     return {
         "connector_id": "api-connector",
         "connector_type": "api",
@@ -85,7 +85,7 @@ def _sevdesk_connection_config():
 
 
 def _database_connection_config():
-    """PostgreSQL database connection config (compatible with DatabaseConfig)."""
+    """PostgreSQL database connection config."""
     return {
         "connector_id": "pg-connector",
         "connector_type": "database",
@@ -181,20 +181,25 @@ def _make_stream_config(source_alias, source_endpoint_id, dest_alias, dest_endpo
     }
 
 
+def _make_runtime(connection_id, connector_type, config, driver=None):
+    """Create a ConnectionRuntime for testing."""
+    return ConnectionRuntime(
+        raw_config=config,
+        connection_id=connection_id,
+        connector_type=connector_type,
+        driver=driver,
+        resolver=AsyncMock(),
+    )
+
+
 def _api_to_api_resolved_connections():
     """Resolved connections for API-to-API (Wise -> SevDesk)."""
     return {
-        WISE_CONNECTION_ID: ResolvedConnection(
-            connection_id=WISE_CONNECTION_ID,
-            connection_type="api",
-            config=_wise_connection_config(),
-            connection_config_wrapper=Mock(),
+        WISE_CONNECTION_ID: _make_runtime(
+            WISE_CONNECTION_ID, "api", _wise_connection_config(),
         ),
-        SEVDESK_CONNECTION_ID: ResolvedConnection(
-            connection_id=SEVDESK_CONNECTION_ID,
-            connection_type="api",
-            config=_sevdesk_connection_config(),
-            connection_config_wrapper=Mock(),
+        SEVDESK_CONNECTION_ID: _make_runtime(
+            SEVDESK_CONNECTION_ID, "api", _sevdesk_connection_config(),
         ),
     }
 
@@ -210,17 +215,11 @@ def _api_to_api_resolved_endpoints():
 def _api_to_db_resolved_connections():
     """Resolved connections for API-to-DB (Wise -> Postgres)."""
     return {
-        WISE_CONNECTION_ID: ResolvedConnection(
-            connection_id=WISE_CONNECTION_ID,
-            connection_type="api",
-            config=_wise_connection_config(),
-            connection_config_wrapper=Mock(),
+        WISE_CONNECTION_ID: _make_runtime(
+            WISE_CONNECTION_ID, "api", _wise_connection_config(),
         ),
-        DB_CONNECTION_ID: ResolvedConnection(
-            connection_id=DB_CONNECTION_ID,
-            connection_type="database",
-            config=_database_connection_config(),
-            connection_config_wrapper=Mock(),
+        DB_CONNECTION_ID: _make_runtime(
+            DB_CONNECTION_ID, "database", _database_connection_config(), driver="postgresql",
         ),
     }
 
@@ -272,18 +271,16 @@ class TestAPIToAPIConfigStructure:
         return pipeline_config, stream_configs, resolved_connections, resolved_endpoints
 
     def test_source_connection_has_api_fields(self, api_to_api_config):
-        """Verify API source connection has required fields for APIConnectionConfig."""
+        """Verify API source connection has required fields."""
         pipeline_config, _, resolved_connections, _ = api_to_api_config
 
         source_refs = pipeline_config["connections"]["source"]
         source_connection_id = list(source_refs.values())[0]
 
-        assert source_connection_id in resolved_connections, (
-            f"Source connection {source_connection_id} not in resolved connections"
-        )
+        assert source_connection_id in resolved_connections
 
-        source_conn = resolved_connections[source_connection_id]
-        config = source_conn.config
+        runtime = resolved_connections[source_connection_id]
+        config = runtime.raw_config
 
         assert "host" in config, "API connection must have host"
         assert config["host"].startswith("http"), f"Host should be URL, got: {config['host']}"
@@ -296,12 +293,10 @@ class TestAPIToAPIConfigStructure:
         dest_refs = pipeline_config["connections"]["destinations"][0]
         dest_connection_id = list(dest_refs.values())[0]
 
-        assert dest_connection_id in resolved_connections, (
-            f"Destination connection {dest_connection_id} not in resolved connections"
-        )
+        assert dest_connection_id in resolved_connections
 
-        dest_conn = resolved_connections[dest_connection_id]
-        config = dest_conn.config
+        runtime = resolved_connections[dest_connection_id]
+        config = runtime.raw_config
 
         assert "host" in config, "API connection must have host"
         assert "parameters" in config, "API connection must have parameters"
@@ -379,13 +374,9 @@ class TestAPIToDatabaseConfigStructure:
         source_refs = pipeline_config["connections"]["source"]
         source_connection_id = list(source_refs.values())[0]
 
-        source_conn = resolved_connections[source_connection_id]
-        config = source_conn.config
-
-        assert config.get("connector_type") == "api" or config.get("type") == "api", (
-            f"Source should be API type, got: {config}"
-        )
-        assert "host" in config, "API source must have 'host'"
+        runtime = resolved_connections[source_connection_id]
+        assert runtime.connector_type == "api"
+        assert "host" in runtime.raw_config
 
     def test_destination_connection_is_database_type(self, api_to_db_config):
         """Verify database dest has driver, host, port, database, username."""
@@ -394,12 +385,8 @@ class TestAPIToDatabaseConfigStructure:
         dest_refs = pipeline_config["connections"]["destinations"][0]
         dest_connection_id = list(dest_refs.values())[0]
 
-        dest_conn = resolved_connections[dest_connection_id]
-        config = dest_conn.config
-
-        assert config.get("connector_type") == "database" or config.get("type") == "database", (
-            f"Destination should be database type, got type: {config.get('type')}"
-        )
+        runtime = resolved_connections[dest_connection_id]
+        assert runtime.connector_type == "database"
 
     def test_database_fields_validated(self, api_to_db_config):
         """Verify port is int type, database/username present in parameters."""
@@ -408,8 +395,8 @@ class TestAPIToDatabaseConfigStructure:
         dest_refs = pipeline_config["connections"]["destinations"][0]
         dest_connection_id = list(dest_refs.values())[0]
 
-        dest_conn = resolved_connections[dest_connection_id]
-        config = dest_conn.config
+        runtime = resolved_connections[dest_connection_id]
+        config = runtime.raw_config
 
         assert "host" in config, "Database connection must have 'host'"
         assert "parameters" in config, "Database connection must have 'parameters'"
@@ -426,20 +413,20 @@ class TestEndToEndConfigFlow:
     """Complete flow tests from constructed configs to Engine."""
 
     def test_api_connection_config_has_required_fields(self):
-        """APIConnector.connect() receives a dict with host and parameters."""
+        """APIConnector.connect() receives a runtime with host and parameters."""
         resolved_connections = _api_to_api_resolved_connections()
-        source_conn = resolved_connections[WISE_CONNECTION_ID]
-        config = source_conn.config
+        runtime = resolved_connections[WISE_CONNECTION_ID]
+        config = runtime.raw_config
 
         assert config["host"]
         assert isinstance(config["parameters"]["headers"], dict)
         assert config["parameters"]["timeout"] > 0
 
     def test_database_connection_config_validates_for_connector(self):
-        """DatabaseConnector.connect() requires 'host' at root and DB fields in parameters."""
+        """DatabaseConnector needs 'host' at root and DB fields in parameters."""
         resolved_connections = _api_to_db_resolved_connections()
-        dest_conn = resolved_connections[DB_CONNECTION_ID]
-        config = dest_conn.config
+        runtime = resolved_connections[DB_CONNECTION_ID]
+        config = runtime.raw_config
 
         assert config.get("host"), "Database connection must have 'host'"
         params = config.get("parameters", {})

--- a/tests/integration/test_database_connector.py
+++ b/tests/integration/test_database_connector.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock
 
 from sqlalchemy import text
 from src.source.connectors.database import DatabaseConnector
+from src.shared.connection_runtime import ConnectionRuntime
 from src.shared.database_utils import acquire_connection
+from src.secrets.resolvers.memory import InMemorySecretsResolver
 
 
 def _postgres_configured() -> bool:
@@ -38,6 +40,19 @@ def database_config():
 
 
 @pytest.fixture
+def database_runtime(database_config):
+    """ConnectionRuntime for real database tests."""
+    resolver = InMemorySecretsResolver({})
+    return ConnectionRuntime(
+        raw_config=database_config,
+        connection_id="test-conn",
+        connector_type="database",
+        driver="postgresql",
+        resolver=resolver,
+    )
+
+
+@pytest.fixture
 def unique_table_name():
     """Generate unique table name for test isolation."""
     return f"test_connector_{uuid.uuid4().hex[:8]}"
@@ -56,11 +71,11 @@ class TestDatabaseConnectorRealIntegration:
     """Integration tests using real PostgreSQL database."""
 
     @pytest.mark.asyncio
-    async def test_connect_and_disconnect(self, database_config):
+    async def test_connect_and_disconnect(self, database_runtime):
         """Test real database connection and disconnection."""
         connector = DatabaseConnector("RealTestConnector")
 
-        await connector.connect(database_config)
+        await connector.connect(database_runtime)
 
         assert connector.is_connected is True
         assert connector._initialized is True
@@ -75,13 +90,13 @@ class TestDatabaseConnectorRealIntegration:
 
     @pytest.mark.asyncio
     async def test_read_batches_pagination(
-        self, database_config, unique_table_name, mock_state_manager
+        self, database_runtime, unique_table_name, mock_state_manager
     ):
         """Test that read_batches correctly paginates through large datasets."""
         connector = DatabaseConnector("RealPaginationConnector")
 
         try:
-            await connector.connect(database_config)
+            await connector.connect(database_runtime)
 
             # Create table and insert data directly via the engine
             async with connector._engine.begin() as conn:

--- a/tests/integration/test_duplicate_records_integration.py
+++ b/tests/integration/test_duplicate_records_integration.py
@@ -14,7 +14,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime, timezone
 
 from src.source.connectors.api import APIConnector
+from src.shared.connection_runtime import ConnectionRuntime
+from src.secrets.resolvers.memory import InMemorySecretsResolver
 from src.state.state_manager import StateManager
+
+
+def _make_api_runtime(host="https://api.test.com"):
+    """Create a ConnectionRuntime for API tests."""
+    return ConnectionRuntime(
+        raw_config={
+            "host": host,
+            "parameters": {
+                "headers": {"Authorization": "Bearer test-token"},
+                "timeout": 30,
+            },
+        },
+        connector_type="api",
+        driver=None,
+        connection_id="test-conn",
+        resolver=InMemorySecretsResolver({}),
+    )
 
 
 class TestDuplicateRecordsIntegration:
@@ -249,11 +268,7 @@ class TestDuplicateRecordsIntegration:
         connector.base_url = "https://api.test.com"
         
         # Connect the API connector to initialize session  
-        await connector.connect({
-            "host": "https://api.test.com",
-            "headers": {"Authorization": "Bearer test-token"},
-            "timeout": 30
-        })
+        await connector.connect(_make_api_runtime())
         
         # Create state manager
         state_manager = StateManager("test-pipeline", str(temp_state_dir))
@@ -323,11 +338,7 @@ class TestDuplicateRecordsIntegration:
         connector.base_url = "https://api.test.com"
         
         # Connect the API connector to initialize session
-        await connector.connect({
-            "host": "https://api.test.com",
-            "headers": {"Authorization": "Bearer test-token"},
-            "timeout": 30
-        })
+        await connector.connect(_make_api_runtime())
         
         # Create state manager
         state_manager = StateManager("test-pipeline", str(temp_state_dir))
@@ -463,11 +474,7 @@ class TestDuplicateRecordsIntegration:
         }
 
         connector = APIConnector("test-api")
-        await connector.connect({
-            "host": "https://api.test.com",
-            "headers": {"Authorization": "Bearer test-token"},
-            "timeout": 30
-        })
+        await connector.connect(_make_api_runtime())
         
         state_manager = StateManager("test-pipeline", str(temp_state_dir))
         
@@ -514,11 +521,7 @@ class TestDuplicateRecordsIntegration:
         }
 
         connector = APIConnector("test-api")
-        await connector.connect({
-            "host": "https://api.test.com",
-            "headers": {"Authorization": "Bearer test-token"},
-            "timeout": 30
-        })
+        await connector.connect(_make_api_runtime())
         
         state_manager = StateManager("test-pipeline", str(temp_state_dir))
         
@@ -591,11 +594,7 @@ class TestDuplicateRecordsIntegration:
         }
 
         connector = APIConnector("test-api")
-        await connector.connect({
-            "host": "https://api.test.com",
-            "headers": {"Authorization": "Bearer test-token"},
-            "timeout": 30
-        })
+        await connector.connect(_make_api_runtime())
         
         state_manager = StateManager("test-pipeline", str(temp_state_dir))
         
@@ -658,11 +657,7 @@ class TestDuplicateRecordsIntegration:
         }
 
         connector = APIConnector("test-api")
-        await connector.connect({
-            "host": "https://api.test.com",
-            "headers": {"Authorization": "Bearer test-token"},
-            "timeout": 30
-        })
+        await connector.connect(_make_api_runtime())
         
         state_manager = StateManager("test-pipeline", str(temp_state_dir))
         

--- a/tests/unit/analitiq_stream/connectors/test_database_connector_unit.py
+++ b/tests/unit/analitiq_stream/connectors/test_database_connector_unit.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 
 from src.source.connectors.database import DatabaseConnector
 from src.source.connectors.base import ConnectionError, ReadError
+from src.shared.connection_runtime import ConnectionRuntime
 
 
 @pytest.fixture
@@ -21,6 +22,18 @@ def database_config():
             "password": "test_password",
         },
     }
+
+
+@pytest.fixture
+def database_runtime(database_config):
+    """ConnectionRuntime for database tests."""
+    return ConnectionRuntime(
+        raw_config=database_config,
+        connection_id="test-conn",
+        connector_type="database",
+        driver="postgresql",
+        resolver=AsyncMock(),
+    )
 
 
 @pytest.fixture
@@ -79,31 +92,30 @@ class TestDatabaseConnectorConnection:
     """Test DatabaseConnector connection management."""
 
     @pytest.mark.asyncio
-    async def test_connect_success(self, connector, database_config):
+    async def test_connect_success(self, connector, database_runtime):
         """Test successful database connection."""
         mock_engine = AsyncMock()
 
         with patch(
-            'src.source.connectors.database.create_database_engine',
+            'src.shared.connection_runtime.create_database_engine',
             return_value=(mock_engine, "postgresql"),
-        ) as mock_create:
-            await connector.connect(database_config)
+        ):
+            await connector.connect(database_runtime)
 
-            mock_create.assert_called_once_with(database_config, require_port=True)
             assert connector.is_connected is True
             assert connector._initialized is True
             assert connector._engine is mock_engine
             assert connector._driver == "postgresql"
 
     @pytest.mark.asyncio
-    async def test_connect_engine_error(self, connector, database_config):
+    async def test_connect_engine_error(self, connector, database_runtime):
         """Test connection failure at engine level."""
         with patch(
-            'src.source.connectors.database.create_database_engine',
+            'src.shared.connection_runtime.create_database_engine',
             side_effect=Exception("Engine creation failed"),
         ):
             with pytest.raises(ConnectionError) as exc_info:
-                await connector.connect(database_config)
+                await connector.connect(database_runtime)
 
             assert "Database connection failed" in str(exc_info.value)
             assert connector.is_connected is False
@@ -113,13 +125,15 @@ class TestDatabaseConnectorConnection:
     async def test_disconnect(self, connector):
         """Test database disconnection."""
         mock_engine = AsyncMock()
+        mock_runtime = AsyncMock()
+        connector._runtime = mock_runtime
         connector._engine = mock_engine
         connector.is_connected = True
         connector._initialized = True
 
         await connector.disconnect()
 
-        mock_engine.dispose.assert_awaited_once()
+        mock_runtime.close.assert_awaited_once()
         assert connector._engine is None
         assert connector.is_connected is False
         assert connector._initialized is False
@@ -283,22 +297,22 @@ class TestDatabaseConnectorContextManager:
     """Test DatabaseConnector context manager behavior."""
 
     @pytest.mark.asyncio
-    async def test_context_manager_usage(self, database_config):
+    async def test_context_manager_usage(self, database_runtime):
         """Test connector as context manager."""
         mock_engine = AsyncMock()
 
         with patch(
-            'src.source.connectors.database.create_database_engine',
+            'src.shared.connection_runtime.create_database_engine',
             return_value=(mock_engine, "postgresql"),
         ):
             connector = DatabaseConnector("ContextTestConnector")
-            await connector.connect(database_config)
+            await connector.connect(database_runtime)
 
             assert connector.is_connected is True
 
             await connector.disconnect()
 
-            mock_engine.dispose.assert_awaited_once()
+            assert connector.is_connected is False
 
 
 class TestDatabaseConnectorImports:

--- a/tests/unit/analitiq_stream/core/test_engine_unit.py
+++ b/tests/unit/analitiq_stream/core/test_engine_unit.py
@@ -131,12 +131,12 @@ class TestStreamingEngine:
         with pytest.raises(ConfigurationError, match="No streams configured"):
             await engine.stream_data(config)
 
-    def test_get_connector_unknown_type(self, engine):
-        """Test error handling for missing connector_id."""
+    def test_create_source_connector_missing_runtime(self, engine):
+        """Test error handling when _runtime is missing."""
         config = {"type": "unknown"}
 
-        with pytest.raises(ValueError, match="missing 'connector_id'"):
-            engine._get_connector(config)
+        with pytest.raises(ValueError, match="Missing _runtime"):
+            engine._create_source_connector(config)
 
     def test_get_stream_name(self, engine):
         """Test stream name generation."""

--- a/tests/unit/analitiq_stream/core/test_pipeline_config_prep.py
+++ b/tests/unit/analitiq_stream/core/test_pipeline_config_prep.py
@@ -358,7 +358,7 @@ class TestConfigurationLoading:
 
             # Check connections are resolved
             assert "source-connection-id" in connections
-            assert connections["source-connection-id"].connection_type == "api"
+            assert connections["source-connection-id"].connector_type == "api"
 
     def test_endpoint_resolution(
         self,

--- a/tests/unit/destination/handlers/test_database_handler.py
+++ b/tests/unit/destination/handlers/test_database_handler.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from sqlalchemy.engine import URL
 
 from src.destination.connectors.database import DatabaseDestinationHandler
+from src.shared.connection_runtime import ConnectionRuntime
 
 
 @pytest.fixture
@@ -29,75 +30,85 @@ def base_config():
     }
 
 
+def _make_runtime(config, driver="postgresql"):
+    return ConnectionRuntime(
+        raw_config=config,
+        connection_id="test-conn",
+        connector_type="database",
+        driver=driver,
+        resolver=AsyncMock(),
+    )
+
+
 class TestDatabaseHandlerConnect:
-    """Test connect() delegates to shared create_database_engine."""
+    """Test connect() delegates to ConnectionRuntime.materialize()."""
 
     @pytest.mark.asyncio
     async def test_connect_success(self, handler, base_config):
-        """connect() should delegate to create_database_engine and set state."""
+        """connect() should materialize runtime and set state."""
         mock_engine = AsyncMock()
+        runtime = _make_runtime(base_config)
 
         with patch(
-            "src.destination.connectors.database.create_database_engine",
+            "src.shared.connection_runtime.create_database_engine",
             return_value=(mock_engine, "postgresql"),
-        ) as mock_create:
-            await handler.connect(base_config)
+        ):
+            await handler.connect(runtime)
 
-        mock_create.assert_called_once_with(base_config, require_port=False)
         assert handler._connected is True
         assert handler._engine is mock_engine
         assert handler._driver == "postgresql"
 
     @pytest.mark.asyncio
     async def test_connect_failure_propagates(self, handler, base_config):
-        """connect() should propagate errors from create_database_engine."""
+        """connect() should propagate errors from materialize."""
+        runtime = _make_runtime(base_config)
+
         with patch(
-            "src.destination.connectors.database.create_database_engine",
+            "src.shared.connection_runtime.create_database_engine",
             side_effect=OSError("Connection timed out"),
         ):
             with pytest.raises(OSError, match="Connection timed out"):
-                await handler.connect(base_config)
+                await handler.connect(runtime)
 
         assert handler._connected is False
 
     @pytest.mark.asyncio
     async def test_connect_ssl_error_propagates(self, handler, base_config):
-        """SSL errors are handled by the shared engine factory, not here."""
+        """SSL errors are propagated from materialize."""
+        runtime = _make_runtime(base_config)
+
         with patch(
-            "src.destination.connectors.database.create_database_engine",
+            "src.shared.connection_runtime.create_database_engine",
             side_effect=ssl.SSLError("SSL handshake failed"),
         ):
             with pytest.raises(ssl.SSLError):
-                await handler.connect(base_config)
+                await handler.connect(runtime)
 
         assert handler._connected is False
 
     @pytest.mark.asyncio
     async def test_sqlite_connect(self, handler):
-        """SQLite connections should work through shared factory."""
+        """SQLite connections should work through runtime materialization."""
         sqlite_config = {
             "driver": "sqlite",
             "database": ":memory:",
         }
+        runtime = _make_runtime(sqlite_config, driver="sqlite")
         mock_engine = AsyncMock()
 
         with patch(
-            "src.destination.connectors.database.create_database_engine",
+            "src.shared.connection_runtime.create_database_engine",
             return_value=(mock_engine, "sqlite"),
-        ) as mock_create:
-            await handler.connect(sqlite_config)
+        ):
+            await handler.connect(runtime)
 
-        mock_create.assert_called_once_with(sqlite_config, require_port=False)
         assert handler._connected is True
         assert handler._driver == "sqlite"
 
 
 class TestDatabaseHandlerURLEncoding:
-    """Test that connection URLs use sqlalchemy.engine.URL (no raw f-string).
-
-    This is now guaranteed by the shared engine factory which uses
-    DatabaseConnectionParams.to_sqlalchemy_url() internally.
-    """
+    """Test that connection URLs use sqlalchemy.engine.URL (no raw f-string)."""
 
     @pytest.mark.asyncio
     async def test_reserved_char_password_works(self, handler):
@@ -112,12 +123,13 @@ class TestDatabaseHandlerURLEncoding:
                 "password": "a@b#c%/d:e",
             },
         }
+        runtime = _make_runtime(config)
         mock_engine = AsyncMock()
 
         with patch(
-            "src.destination.connectors.database.create_database_engine",
+            "src.shared.connection_runtime.create_database_engine",
             return_value=(mock_engine, "postgresql"),
         ):
-            await handler.connect(config)
+            await handler.connect(runtime)
 
         assert handler._connected is True

--- a/tests/unit/destination/handlers/test_database_handler.py
+++ b/tests/unit/destination/handlers/test_database_handler.py
@@ -75,14 +75,14 @@ class TestDatabaseHandlerConnect:
 
     @pytest.mark.asyncio
     async def test_connect_ssl_error_propagates(self, handler, base_config):
-        """SSL errors are propagated from materialize."""
+        """SSL errors are wrapped in ConnectionError from materialize."""
         runtime = _make_runtime(base_config)
 
         with patch(
             "src.shared.connection_runtime.create_database_engine",
             side_effect=ssl.SSLError("SSL handshake failed"),
         ):
-            with pytest.raises(ssl.SSLError):
+            with pytest.raises(ConnectionError, match="Database connection failed"):
                 await handler.connect(runtime)
 
         assert handler._connected is False

--- a/tests/unit/engine/test_connection_secret_resolution.py
+++ b/tests/unit/engine/test_connection_secret_resolution.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.shared.connection_runtime import ConnectionRuntime
+from src.secrets.exceptions import PlaceholderExpansionError
 
 
 class TestConnectionRuntimeMetadata:
@@ -21,7 +22,7 @@ class TestConnectionRuntimeMetadata:
         assert runtime.driver == "postgresql"
         assert runtime.connection_id == "conn-1"
 
-    def test_raw_config_available(self):
+    def test_raw_config_returns_deep_copy(self):
         config = {"host": "localhost", "parameters": {"port": 5432}}
         runtime = ConnectionRuntime(
             raw_config=config,
@@ -30,7 +31,22 @@ class TestConnectionRuntimeMetadata:
             driver="postgresql",
             resolver=AsyncMock(),
         )
-        assert runtime.raw_config is config
+        result = runtime.raw_config
+        assert result == config
+        assert result is not config
+        # Mutating the copy should not affect internal state
+        result["host"] = "mutated"
+        assert runtime.raw_config["host"] == "localhost"
+
+    def test_invalid_connector_type_raises(self):
+        with pytest.raises(ValueError, match="Invalid connector_type"):
+            ConnectionRuntime(
+                raw_config={"host": "localhost"},
+                connection_id="conn-1",
+                connector_type="foobar",
+                driver=None,
+                resolver=AsyncMock(),
+            )
 
 
 class TestConnectionRuntimeResolveSecrets:
@@ -68,6 +84,23 @@ class TestConnectionRuntimeResolveSecrets:
 
         mock_resolver.resolve.assert_awaited_once_with("conn-with-secrets", org_id=None)
         assert runtime.resolved_config["parameters"]["password"] == "secret123"
+
+    @pytest.mark.asyncio
+    async def test_missing_secret_key_raises_placeholder_error(self):
+        mock_resolver = AsyncMock()
+        mock_resolver.resolve.return_value = {"OTHER_KEY": "value"}
+        runtime = ConnectionRuntime(
+            raw_config={"host": "localhost", "token": "${MISSING_KEY}"},
+            connection_id="conn-missing",
+            connector_type="file",
+            driver=None,
+            resolver=mock_resolver,
+        )
+
+        with pytest.raises(PlaceholderExpansionError) as exc_info:
+            await runtime.materialize()
+
+        assert "MISSING_KEY" in str(exc_info.value)
 
 
 class TestConnectionRuntimeMaterialize:
@@ -148,7 +181,7 @@ class TestConnectionRuntimeMaterialize:
         )
 
         with patch(
-            "src.shared.connection_runtime.create_api_session",
+            "src.shared.connection_runtime._create_api_session",
             return_value=(mock_session, "https://api.example.com", mock_rate_limiter),
         ):
             await runtime.materialize()
@@ -177,10 +210,32 @@ class TestConnectionRuntimeMaterialize:
         with patch("src.shared.connection_runtime.create_database_engine", return_value=(AsyncMock(), "postgresql")):
             await runtime.materialize()
 
-        # Secrets should be scrubbed
         assert runtime._secrets is None
-        # For database, resolved config should also be scrubbed
         assert runtime._resolved_config is None
+
+    @pytest.mark.asyncio
+    async def test_secrets_scrubbed_on_materialize_failure(self):
+        mock_resolver = AsyncMock()
+        mock_resolver.resolve.return_value = {"DB_PASS": "secret"}
+
+        runtime = ConnectionRuntime(
+            raw_config={
+                "host": "localhost",
+                "driver": "postgresql",
+                "parameters": {"password": "${DB_PASS}"},
+            },
+            connection_id="conn-db",
+            connector_type="database",
+            driver="postgresql",
+            resolver=mock_resolver,
+        )
+
+        with patch("src.shared.connection_runtime.create_database_engine", side_effect=Exception("connection failed")):
+            with pytest.raises(Exception, match="connection failed"):
+                await runtime.materialize()
+
+        # Secrets should still be scrubbed even on failure
+        assert runtime._secrets is None
 
 
 class TestConnectionRuntimeClose:
@@ -204,6 +259,24 @@ class TestConnectionRuntimeClose:
         mock_engine.dispose.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_close_disposes_session(self):
+        mock_session = AsyncMock()
+        runtime = ConnectionRuntime(
+            raw_config={"host": "https://api.example.com", "parameters": {}},
+            connection_id="conn-api",
+            connector_type="api",
+            driver=None,
+            resolver=AsyncMock(),
+        )
+
+        with patch("src.shared.connection_runtime._create_api_session", return_value=(mock_session, "https://api.example.com", None)):
+            await runtime.materialize()
+
+        await runtime.close()
+        mock_session.close.assert_awaited_once()
+        assert not runtime._materialized
+
+    @pytest.mark.asyncio
     async def test_double_close_is_safe(self):
         mock_engine = AsyncMock()
         runtime = ConnectionRuntime(
@@ -219,3 +292,50 @@ class TestConnectionRuntimeClose:
 
         await runtime.close()
         await runtime.close()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_close_engine_failure_still_closes_session(self):
+        """If engine.dispose() fails, session.close() should still be called."""
+        mock_engine = AsyncMock()
+        mock_engine.dispose.side_effect = Exception("dispose failed")
+        mock_session = AsyncMock()
+
+        runtime = ConnectionRuntime(
+            raw_config={"host": "localhost"},
+            connection_id="conn-1",
+            connector_type="database",
+            driver="postgresql",
+            resolver=AsyncMock(),
+        )
+        # Manually set state to simulate both engine and session
+        runtime._engine = mock_engine
+        runtime._session = mock_session
+        runtime._materialized = True
+
+        with pytest.raises(Exception, match="dispose failed"):
+            await runtime.close()
+
+        # Session should still be closed despite engine failure
+        mock_session.close.assert_awaited_once()
+
+
+class TestCreateSourceConnectorUnknownType:
+    """Test _create_source_connector with unknown connector_type."""
+
+    def test_unknown_connector_type_raises(self):
+        from src.engine.engine import StreamingEngine
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = StreamingEngine(
+                pipeline_id="test", dlq_path=tmp
+            )
+            runtime = ConnectionRuntime(
+                raw_config={},
+                connection_id="conn-1",
+                connector_type="file",
+                driver=None,
+                resolver=AsyncMock(),
+            )
+            config = {"_runtime": runtime}
+            with pytest.raises(ValueError, match="Unknown connector_type 'file'"):
+                engine._create_source_connector(config)

--- a/tests/unit/engine/test_connection_secret_resolution.py
+++ b/tests/unit/engine/test_connection_secret_resolution.py
@@ -312,11 +312,12 @@ class TestConnectionRuntimeClose:
         runtime._session = mock_session
         runtime._materialized = True
 
-        with pytest.raises(Exception, match="dispose failed"):
-            await runtime.close()
+        # close() should not raise — it logs the error and continues cleanup
+        await runtime.close()
 
         # Session should still be closed despite engine failure
         mock_session.close.assert_awaited_once()
+        assert runtime._materialized is False
 
 
 class TestCreateSourceConnectorUnknownType:

--- a/tests/unit/engine/test_connection_secret_resolution.py
+++ b/tests/unit/engine/test_connection_secret_resolution.py
@@ -1,172 +1,221 @@
-"""Tests for connection secret resolution in the engine pipeline."""
+"""Tests for ConnectionRuntime secret resolution and lifecycle."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from src.engine.pipeline_config_prep import ResolvedConnection
-from src.secrets.config_wrapper import ConnectionConfig
+from src.shared.connection_runtime import ConnectionRuntime
 
 
-class TestBuildConfigDictCarriesConnectionWrapper:
-    """Test that get_connection_config propagates _connection_wrapper."""
+class TestConnectionRuntimeMetadata:
+    """Test that ConnectionRuntime exposes enriched metadata before materialize."""
 
-    def test_resolved_connection_wrapper_in_config(self):
-        """Verify ResolvedConnection config copy includes wrapper
-        when accessed through the pipeline's get_connection_config pattern."""
-        mock_wrapper = MagicMock()
-        raw_config = {
-            "host": "db.example.com",
-            "driver": "postgresql",
-            "parameters": {
-                "port": 5432,
-                "password": "${password}",
-            },
-        }
-        resolved_conn = ResolvedConnection(
+    def test_connector_type_available(self):
+        runtime = ConnectionRuntime(
+            raw_config={"host": "localhost"},
             connection_id="conn-1",
-            connection_type="database",
-            config=raw_config,
-            connection_config_wrapper=mock_wrapper,
+            connector_type="database",
+            driver="postgresql",
+            resolver=AsyncMock(),
         )
+        assert runtime.connector_type == "database"
+        assert runtime.driver == "postgresql"
+        assert runtime.connection_id == "conn-1"
 
-        # Simulate what get_connection_config now does (pipeline.py line 381)
-        result = resolved_conn.config.copy()
-        result["_connection_wrapper"] = resolved_conn.connection_config_wrapper
-
-        assert "_connection_wrapper" in result
-        assert result["_connection_wrapper"] is mock_wrapper
-        # Original config should not be modified
-        assert "_connection_wrapper" not in resolved_conn.config
-
-    def test_dict_connection_has_no_wrapper(self):
-        """When resolved_connections stores a plain dict, no wrapper is added."""
-        raw_config = {
-            "host": "db.example.com",
-            "driver": "postgresql",
-            "parameters": {
-                "port": 5432,
-                "password": "plain",
-            },
-        }
-
-        # Simulate the dict branch of get_connection_config
-        result = raw_config.copy()
-
-        assert "_connection_wrapper" not in result
+    def test_raw_config_available(self):
+        config = {"host": "localhost", "parameters": {"port": 5432}}
+        runtime = ConnectionRuntime(
+            raw_config=config,
+            connection_id="conn-1",
+            connector_type="database",
+            driver="postgresql",
+            resolver=AsyncMock(),
+        )
+        assert runtime.raw_config is config
 
 
-class TestProcessStreamResolvesWrapper:
-    """Test that _process_stream resolves wrapper before connecting."""
-
-    @pytest.mark.asyncio
-    async def test_resolves_wrapper_before_connect(self):
-        """When _connection_wrapper is present in merged source config,
-        engine must await wrapper.resolve() and pass the resolved dict
-        (not the raw one with ${password}) to source_connector.connect()."""
-        resolved_config = {
-            "host": "db.example.com",
-            "driver": "postgresql",
-            "parameters": {
-                "port": 5432,
-                "password": "actual-secret",
-            },
-        }
-
-        mock_wrapper = AsyncMock()
-        mock_wrapper.resolve.return_value = resolved_config
-
-        mock_source_connector = AsyncMock()
-
-        merged_src_config = {
-            "_connection_wrapper": mock_wrapper,
-            "_connection": {
-                "host": "db.example.com",
-                "driver": "postgresql",
-                "parameters": {
-                    "port": 5432,
-                    "password": "${password}",
-                },
-            },
-        }
-
-        # Replicate the resolution logic from engine.py lines 280-284
-        connection_wrapper = merged_src_config.get("_connection_wrapper")
-        if connection_wrapper is not None:
-            src_connection_config = await connection_wrapper.resolve()
-        else:
-            src_connection_config = merged_src_config.get(
-                "_connection", merged_src_config
-            )
-
-        await mock_source_connector.connect(src_connection_config)
-
-        mock_wrapper.resolve.assert_awaited_once()
-        mock_source_connector.connect.assert_awaited_once_with(resolved_config)
-        call_args = mock_source_connector.connect.call_args[0][0]
-        assert call_args["parameters"]["password"] == "actual-secret"
-        assert "${password}" not in str(call_args)
-
-    @pytest.mark.asyncio
-    async def test_falls_back_to_connection_without_wrapper(self):
-        """When _connection_wrapper is absent, engine uses _connection directly."""
-        raw_config = {
-            "host": "db.example.com",
-            "driver": "postgresql",
-            "parameters": {
-                "port": 5432,
-                "password": "plain-password",
-            },
-        }
-
-        merged_src_config = {
-            "_connection": raw_config,
-        }
-
-        connection_wrapper = merged_src_config.get("_connection_wrapper")
-        if connection_wrapper is not None:
-            src_connection_config = await connection_wrapper.resolve()
-        else:
-            src_connection_config = merged_src_config.get(
-                "_connection", merged_src_config
-            )
-
-        assert src_connection_config is raw_config
-        assert src_connection_config["parameters"]["password"] == "plain-password"
-
-
-class TestConnectionConfigResolveShortCircuit:
-    """Test that resolve() skips secret fetching when no placeholders exist."""
+class TestConnectionRuntimeResolveSecrets:
+    """Test secret resolution inside materialize."""
 
     @pytest.mark.asyncio
     async def test_resolve_without_placeholders_skips_resolver(self):
-        """When config has no ${placeholder} values, resolve() should return
-        the raw config without calling the secrets resolver."""
         mock_resolver = AsyncMock()
-        config = ConnectionConfig(
-            raw_config={"host": "localhost", "driver": "postgresql", "parameters": {"port": 5432, "password": "literal"}},
+        runtime = ConnectionRuntime(
+            raw_config={"host": "localhost", "parameters": {"port": 5432, "password": "literal"}},
             connection_id="conn-no-secrets",
+            connector_type="file",
+            driver=None,
             resolver=mock_resolver,
         )
 
-        result = await config.resolve()
+        await runtime.materialize()
 
         mock_resolver.resolve.assert_not_awaited()
-        assert result["parameters"]["password"] == "literal"
-        assert result["host"] == "localhost"
+        assert runtime.resolved_config["host"] == "localhost"
 
     @pytest.mark.asyncio
     async def test_resolve_with_placeholders_calls_resolver(self):
-        """When config has ${placeholder} values, resolve() must call the
-        secrets resolver and expand them."""
         mock_resolver = AsyncMock()
         mock_resolver.resolve.return_value = {"DB_PASS": "secret123"}
-        config = ConnectionConfig(
-            raw_config={"host": "localhost", "driver": "postgresql", "parameters": {"password": "${DB_PASS}"}},
+        runtime = ConnectionRuntime(
+            raw_config={"host": "localhost", "parameters": {"password": "${DB_PASS}"}},
             connection_id="conn-with-secrets",
+            connector_type="file",
+            driver=None,
             resolver=mock_resolver,
         )
 
-        result = await config.resolve()
+        await runtime.materialize()
 
         mock_resolver.resolve.assert_awaited_once_with("conn-with-secrets", org_id=None)
-        assert result["parameters"]["password"] == "secret123"
+        assert runtime.resolved_config["parameters"]["password"] == "secret123"
+
+
+class TestConnectionRuntimeMaterialize:
+    """Test materialize creates correct transport per connector_type."""
+
+    @pytest.mark.asyncio
+    async def test_materialize_is_idempotent(self):
+        mock_resolver = AsyncMock()
+        runtime = ConnectionRuntime(
+            raw_config={"host": "localhost", "file_format": "jsonl"},
+            connection_id="conn-1",
+            connector_type="stdout",
+            driver=None,
+            resolver=mock_resolver,
+        )
+
+        await runtime.materialize()
+        first_config = runtime.resolved_config
+
+        # Second call is a no-op
+        await runtime.materialize()
+        assert runtime.resolved_config is first_config
+
+    @pytest.mark.asyncio
+    async def test_transport_accessors_raise_before_materialize(self):
+        runtime = ConnectionRuntime(
+            raw_config={"host": "localhost"},
+            connection_id="conn-1",
+            connector_type="database",
+            driver="postgresql",
+            resolver=AsyncMock(),
+        )
+
+        with pytest.raises(RuntimeError, match="call materialize"):
+            _ = runtime.engine
+
+        with pytest.raises(RuntimeError, match="call materialize"):
+            _ = runtime.session
+
+    @pytest.mark.asyncio
+    async def test_materialize_database(self):
+        mock_resolver = AsyncMock()
+        mock_engine = AsyncMock()
+
+        runtime = ConnectionRuntime(
+            raw_config={
+                "host": "localhost",
+                "driver": "postgresql",
+                "parameters": {"port": 5432, "database": "test", "username": "user", "password": "pass"},
+            },
+            connection_id="conn-db",
+            connector_type="database",
+            driver="postgresql",
+            resolver=mock_resolver,
+        )
+
+        with patch("src.shared.connection_runtime.create_database_engine", return_value=(mock_engine, "postgresql")) as mock_create:
+            await runtime.materialize(require_port=True)
+
+            mock_create.assert_awaited_once()
+            assert runtime.engine is mock_engine
+
+    @pytest.mark.asyncio
+    async def test_materialize_api(self):
+        mock_resolver = AsyncMock()
+        mock_session = AsyncMock()
+        mock_rate_limiter = MagicMock()
+
+        runtime = ConnectionRuntime(
+            raw_config={
+                "host": "https://api.example.com",
+                "parameters": {"timeout": 30},
+            },
+            connection_id="conn-api",
+            connector_type="api",
+            driver=None,
+            resolver=mock_resolver,
+        )
+
+        with patch(
+            "src.shared.connection_runtime.create_api_session",
+            return_value=(mock_session, "https://api.example.com", mock_rate_limiter),
+        ):
+            await runtime.materialize()
+
+            assert runtime.session is mock_session
+            assert runtime.base_url == "https://api.example.com"
+            assert runtime.rate_limiter is mock_rate_limiter
+
+    @pytest.mark.asyncio
+    async def test_secrets_scrubbed_after_materialize_database(self):
+        mock_resolver = AsyncMock()
+        mock_resolver.resolve.return_value = {"DB_PASS": "secret"}
+
+        runtime = ConnectionRuntime(
+            raw_config={
+                "host": "localhost",
+                "driver": "postgresql",
+                "parameters": {"password": "${DB_PASS}"},
+            },
+            connection_id="conn-db",
+            connector_type="database",
+            driver="postgresql",
+            resolver=mock_resolver,
+        )
+
+        with patch("src.shared.connection_runtime.create_database_engine", return_value=(AsyncMock(), "postgresql")):
+            await runtime.materialize()
+
+        # Secrets should be scrubbed
+        assert runtime._secrets is None
+        # For database, resolved config should also be scrubbed
+        assert runtime._resolved_config is None
+
+
+class TestConnectionRuntimeClose:
+    """Test close disposes resources."""
+
+    @pytest.mark.asyncio
+    async def test_close_disposes_engine(self):
+        mock_engine = AsyncMock()
+        runtime = ConnectionRuntime(
+            raw_config={"host": "localhost", "driver": "postgresql", "parameters": {"port": 5432, "database": "test", "username": "u", "password": "p"}},
+            connection_id="conn-db",
+            connector_type="database",
+            driver="postgresql",
+            resolver=AsyncMock(),
+        )
+
+        with patch("src.shared.connection_runtime.create_database_engine", return_value=(mock_engine, "postgresql")):
+            await runtime.materialize()
+
+        await runtime.close()
+        mock_engine.dispose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_double_close_is_safe(self):
+        mock_engine = AsyncMock()
+        runtime = ConnectionRuntime(
+            raw_config={"host": "localhost", "driver": "postgresql", "parameters": {"port": 5432, "database": "test", "username": "u", "password": "p"}},
+            connection_id="conn-db",
+            connector_type="database",
+            driver="postgresql",
+            resolver=AsyncMock(),
+        )
+
+        with patch("src.shared.connection_runtime.create_database_engine", return_value=(mock_engine, "postgresql")):
+            await runtime.materialize()
+
+        await runtime.close()
+        await runtime.close()  # Should not raise


### PR DESCRIPTION
## Summary

- **ConnectionRuntime**: New unified abstraction (`src/shared/connection_runtime.py`) that handles secret resolution, placeholder expansion, and connection parameter merging in one place — replacing scattered logic across engine, destination, and connectors.
- **Removed ORG_ID requirement**: `ORG_ID` is no longer a required env var for Docker containers; it's read from the pipeline config instead.
- **Fixed dataclass serialization bugs**: `StreamCursor` and `StreamStats` are dataclasses, not Pydantic models — replaced `model_dump()` with `asdict()` and added `default=str` to JSON serialization for datetime handling.
- **Simplified connectors**: Source and destination connectors now receive pre-resolved connection configs via `ConnectionRuntime` instead of doing their own secret resolution.
- **Updated tests**: Adapted integration and unit tests to the new connection lifecycle.

## Test plan

- [x] Run `poetry run pytest` to verify all tests pass
- [x] Run pipeline `0569c85b` (Wise → PG) locally with `ENV=loc`
- [x] Run pipeline `a146cfbf` (MySQL → PG) locally with `ENV=loc`
- [x] Run pipeline `22ab7b76` (Wise → Sevdesk) locally — verified extract works, destination API issue is external
- [x] Verify secret resolution works for both source and destination connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)