### PR TITLE
Add opt-in ADBC fast path for database destinations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,88 @@ The engine and destination run from the same Docker image, toggled by `RUN_MODE`
 3. **Load** — write to destination with fault tolerance
 4. **Checkpoint** — save progress so interrupted runs resume automatically
 
+### For databases that support ADBC (Postgres/BigQuery/Snowflake/DuckDB)
+
+Arrow Database Connectivity (https://arrow.apache.org/adbc/) drivers exist for exactly these. The flow is:
+
+record_batch
+→ cast_arrow_batch
+→ adbc_conn.adbc_ingest(table, record_batch, mode="append")
+
+The driver hands the Arrow buffers directly to libpq's binary COPY protocol or BigQuery's storage API.
+
+**First-class native drivers**
+```text
+  ┌────────────┬────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────┐
+  │   Driver   │          Package           │                                        Notes                                         │
+  ├────────────┼────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
+  │ PostgreSQL │ adbc-driver-postgresql     │ Uses libpq COPY BINARY for bulk ingest. Production-ready.                            │                                                                                                                                                                                                                                                        
+  ├────────────┼────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
+  │ Snowflake  │ adbc-driver-snowflake      │ Native Arrow ingestion via internal Go-Snowflake driver.                             │
+  ├────────────┼────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
+  │ BigQuery   │ adbc-driver-bigquery       │ Storage Write API (Arrow-native).                                                    │
+  ├────────────┼────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
+  │ DuckDB     │ shipped with duckdb itself │ Zero-copy in-process.                                                                │
+  ├────────────┼────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
+  │ SQLite     │ adbc-driver-sqlite         │ Production-ready. Less interesting for "millions of records" but useful for testing. │
+  └────────────┴────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────┘
+```
+These five are the ones where cur.adbc_ingest(...) actually skips a row-by-row insert path.
+
+**Flight SQL driver (works for any DB exposing Flight SQL)**
+```text
+  ┌────────────────────┬───────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │       Driver       │        Package        │                                                                                    Covers                                                                                     │
+  ├────────────────────┼───────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ Flight SQL generic │ adbc-driver-flightsql │ Any server that implements the Arrow Flight SQL protocol — currently Dremio, Doris, InfluxDB 3.x, DataBricks (in some configs), and an increasing number of newer warehouses. │
+  └────────────────────┴───────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+Caveat: this only helps if the target server actually exposes a Flight SQL endpoint. Most ordinary MySQL/Postgres deployments do not.
+
+**Bridge drivers (broad coverage, NO columnar benefit)**
+
+```text
+  ┌─────────────┬──────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │   Driver    │     Package      │                                                                                                                              What it does                                                                                                                              │
+  ├─────────────┼──────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ JDBC bridge │ adbc-driver-jdbc │ Wraps any JDBC driver. Gives you "ADBC API surface" over Oracle / MSSQL / MariaDB / MySQL / Redshift / etc. — but underneath it still binds row-by-row through JDBC. Don't pick this for performance. Use it only if you want one ADBC interface across mixed targets. │
+  └─────────────┴──────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+
+### For databases without ADBC: native bulk-load protocols
+
+For PG without ADBC, `COPY FROM stdin BINARY` via `psycopg`. For MySQL, LOAD DATA LOCAL INFILE. Each is ~10x faster than parameterized INSERT, even with batching.
+SQLAlchemy as a generic write path should be the fallback, not the default.
+```text
+  ┌────────────────────┬─────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │         DB         │                              Driver to use                              │                                                                           Bulk path                                                                            │
+  ├────────────────────┼─────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ MySQL / MariaDB    │ PyMySQL or mysqlclient via SQLAlchemy                                   │ LOAD DATA LOCAL INFILE via raw cursor — stream Arrow → CSV/TSV → MySQL reads it directly. ~10x faster than INSERT.                                             │
+  ├────────────────────┼─────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ Oracle             │ python-oracledb via SQLAlchemy                                          │ cursor.executemany(sql, rows) with arraysize tuned. Oracle's batched executemany is the standard fast path; SQL*Loader exists but isn't practical from Python. │
+  ├────────────────────┼─────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ MSSQL / SQL Server │ pyodbc via SQLAlchemy                                                   │ Set fast_executemany=True on the cursor — uses TDS batched parameter stream. Big speedup, single-line config change.                                           │
+  ├────────────────────┼─────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ ClickHouse         │ clickhouse-connect (skip SQLAlchemy)                                    │ client.insert_arrow(table_name, arrow_table) — first-class Arrow ingest, just not branded ADBC.                                                                │
+  ├────────────────────┼─────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ Redshift           │ redshift_connector via SQLAlchemy, OR Postgres ADBC driver (unofficial) │ See note below — the real fast path conflicts with your engine policy.                                                                                         │
+  └────────────────────┴─────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### For API destinations: skip Arrow after the cast
+
+Once the schema is validated, materialize once and stay row-oriented. Use orjson (C-based, handles datetime/Decimal/UUID natively via `default=`) instead of
+stdlib json. This avoids wasting cycles converting decimal → string → dict → json string when it can go decimal → orjson in one step with a custom serializer.
+
+record_batch
+→ cast_arrow_batch          # schema validation only
+→ to_pylist                 # materialize ONCE
+→ orjson.dumps(default=...) # handles Decimal/datetime/UUID without pre-conversion
+→ aiohttp
+
+The whole point of orjson's default= hook is to avoid an explicit "Arrow-level cast to JSON shape" pass.
+
 ## Configuration Layout
 
 Configuration is assembled from modular files. The plugin generates all of this automatically.

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -61,9 +61,10 @@ sqlalchemy[asyncio]>=2.0.0
 pyarrow>=12.0.0
 
 # ADBC (Arrow Database Connectivity) fast path for the database
-# destination. Enabled at runtime via the ``ADBC_FAST_PATH=1`` env var
-# and only when the stream is append-only. SQLAlchemy stays as the
-# fallback for upserts and any driver not covered by ADBC.
+# destination. Always installed in the Docker image; ``ADBC_FAST_PATH=1``
+# at runtime is what gates use. pip consumers see ADBC as the optional
+# ``adbc`` extra in pyproject.toml — the runtime image bundles it so a
+# flag flip needs no rebuild.
 adbc-driver-manager>=1.1.0
 adbc-driver-postgresql>=1.1.0
 

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -60,6 +60,13 @@ sqlalchemy[asyncio]>=2.0.0
 # numpy>=1.24.0
 pyarrow>=12.0.0
 
+# ADBC (Arrow Database Connectivity) fast path for the database
+# destination. Enabled at runtime via the ``ADBC_FAST_PATH=1`` env var
+# and only when the stream is append-only. SQLAlchemy stays as the
+# fallback for upserts and any driver not covered by ADBC.
+adbc-driver-manager>=1.1.0
+adbc-driver-postgresql>=1.1.0
+
 # For NoSQL databases
 # motor>=3.0.0
 # aioredis>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,13 @@ aioredis = {version = "^2.0.0", optional = true}
 cryptography = {version = "^41.0.0", optional = true}
 passlib = {version = "^1.7.4", optional = true}
 apscheduler = {version = "^3.10.0", optional = true}
+
+# ADBC (Arrow Database Connectivity) — opt-in fast path for the
+# database destination. When the driver is importable and
+# ``ADBC_FAST_PATH=1`` is set, append-only writes go through
+# ``adbc_ingest`` instead of SQLAlchemy ``executemany``.
+adbc-driver-manager = {version = "^1.1.0", optional = true}
+adbc-driver-postgresql = {version = "^1.1.0", optional = true}
 strands-agents = "^1.3.0"
 strands-agents-tools = "^0.2.3"
 bedrock-agentcore = "^0.1.2"
@@ -123,13 +130,15 @@ analytics = ["pandas", "numpy"]
 nosql = ["motor", "aioredis"]
 security = ["cryptography", "passlib"]
 scheduling = ["apscheduler"]
+adbc = ["adbc-driver-manager", "adbc-driver-postgresql"]
 all = [
     "kafka-python", "aiokafka",
     "boto3", "azure-storage-blob", "google-cloud-storage",
     "pandas", "numpy",
     "motor", "aioredis",
     "cryptography", "passlib",
-    "apscheduler"
+    "apscheduler",
+    "adbc-driver-manager", "adbc-driver-postgresql"
 ]
 
 [tool.poetry.scripts]

--- a/src/destination/connectors/database.py
+++ b/src/destination/connectors/database.py
@@ -309,16 +309,24 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
         """Close database connection.
 
         Both the ADBC connection and the SQLAlchemy runtime are
-        released even if the other side fails, so neither leaks on top
-        of the other. Close failures are logged at ERROR with
-        ``exc_info``; the handler still transitions to ``_connected =
-        False`` so callers can re-acquire without seeing a half-open
-        state.
+        released even if the other side fails or the coroutine is
+        cancelled mid-close. The ADBC release uses ``BaseException``
+        so ``asyncio.CancelledError`` during shutdown still gives the
+        SQLAlchemy runtime a chance to dispose its engine pool.
+        ``CancelledError`` is re-raised after both releases so the
+        caller's cancellation is honored.
         """
+        cancelled: Optional[BaseException] = None
         adbc_conn = self._adbc_conn
         if adbc_conn is not None:
             try:
                 await asyncio.to_thread(adbc_conn.close)
+            except asyncio.CancelledError as exc:
+                logger.error(
+                    "ADBC close cancelled during disconnect; "
+                    "server-side resources may remain allocated"
+                )
+                cancelled = exc
             except Exception:
                 logger.error(
                     "Failed to close ADBC connection during disconnect; "
@@ -330,6 +338,9 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
         if self._runtime:
             try:
                 await self._runtime.close()
+            except asyncio.CancelledError as exc:
+                logger.error("SQLAlchemy runtime close cancelled during disconnect")
+                cancelled = exc
             except Exception:
                 logger.error(
                     "Failed to close SQLAlchemy runtime during disconnect",
@@ -337,6 +348,8 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
                 )
         self._connected = False
         logger.info("DatabaseDestinationHandler disconnected")
+        if cancelled is not None:
+            raise cancelled
 
     async def configure_schema(self, schema_msg: SchemaMessage) -> bool:
         """Configure the destination from the preloaded contract endpoint.
@@ -681,6 +694,16 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
                 records_written=0,
                 failure_summary=f"adbc: {e}",
             )
+        except AdbcCommitRecordError as e:
+            # Ingest already committed; the SA _batch_commits write
+            # failed. The retry will re-ingest. Stay RETRYABLE so the
+            # engine reconciles, but surface the divergence text in
+            # failure_summary so DLQ / monitoring can route on it.
+            return BatchWriteResult(
+                status=AckStatus.ACK_STATUS_RETRYABLE_FAILURE,
+                records_written=0,
+                failure_summary=str(e),
+            )
         except Exception as e:
             logger.error(f"Error writing batch: {e}", exc_info=True)
             return BatchWriteResult(
@@ -930,14 +953,16 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
     def _can_use_adbc(self, stream_id: str, state: _StreamState) -> bool:
         """Decide whether the current batch takes the ADBC fast path.
 
-        Gated on:
+        Returns ``True`` iff all of the following hold:
 
-        * Opt-in feature flag (``ADBC_FAST_PATH`` env var).
-        * Append-only stream (``write_mode == "insert"``).
+        * Opt-in feature flag (``ADBC_FAST_PATH`` env var) is set.
+        * Stream is append-only (``write_mode == "insert"``);
           ``adbc_ingest`` is INSERT/APPEND only.
         * The dialect is in ``_ADBC_MODULES`` and the matching driver
           package is importable.
         * A connection URI can be built from the engine's URL.
+        * The stream has a configured schema contract (needed for the
+          vectorized cast before ingest).
         """
         if not _adbc_flag_enabled():
             return False
@@ -959,16 +984,19 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
                 "could not build ADBC URI from engine.url",
             )
             return False
+        if state.schema_contract is None:
+            self._note_adbc_demotion(
+                stream_id, state, "stream has no configured schema contract"
+            )
+            return False
         return True
 
     def _open_adbc_connection(self) -> Any:
         """Return the cached ADBC connection, opening it on first use.
 
         Raises :class:`AdbcConfigurationError` when the driver module
-        or URI cannot be produced. The handler-side cache means the
-        connection persists across batches; ``_adbc_ingest_sync``
-        nulls it on any ingest error so a poisoned handle is not
-        reused.
+        or URI cannot be produced. The cached handle is dropped on any
+        ingest error so a poisoned connection is not reused.
         """
         if self._adbc_conn is not None:
             return self._adbc_conn
@@ -995,11 +1023,10 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
 
         Caller must ensure the target table exists.
 
-        On any exception (ingest itself, or cursor.close after a
-        successful ingest), invalidate ``self._adbc_conn`` so the next
-        batch reconnects. ADBC connection state after a backend error
-        is undefined — reusing it tends to produce a flapping retry
-        loop against an already-broken session.
+        Only ingest / cursor failures invalidate ``self._adbc_conn`` —
+        misconfiguration raised by ``_open_adbc_connection`` does not
+        touch a connection (none was opened) and the
+        ``AdbcConfigurationError`` propagates straight through.
         """
         conn = self._open_adbc_connection()
         try:
@@ -1041,15 +1068,15 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
         Reuses :meth:`SchemaContract.cast_arrow_batch` so the Arrow
         types match the destination table exactly. The cast batch is
         handed straight to ADBC — no ``to_pylist()`` round trip, no
-        SQLAlchemy bind-parameter loop.
+        per-row SQLAlchemy parameter loop.
 
-        Idempotency caveat: ``adbc_ingest`` commits on its own ADBC
-        connection, then ``_batch_commits`` is recorded in a separate
-        SQLAlchemy transaction. If the process dies between those two
-        commits, a retry re-inserts the batch. This is acceptable for
-        append-only streams; callers needing exactly-once must stay on
-        the SQLAlchemy path (``write_mode != "insert"``).
+        Append-only: ingest commits before ``_batch_commits`` is
+        recorded; see :class:`AdbcCommitRecordError` for the
+        retry-duplication window.
         """
+        # Defensive — _can_use_adbc gates on schema_contract being set,
+        # so this only triggers if a caller invokes _write_via_adbc
+        # outside of the dispatch in write_batch.
         if state.schema_contract is None:
             raise AdbcConfigurationError(
                 "ADBC fast path requires a configured SchemaContract"

--- a/src/destination/connectors/database.py
+++ b/src/destination/connectors/database.py
@@ -13,8 +13,8 @@ import logging
 import os
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Mapping, Optional
-from urllib.parse import quote
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
+from urllib.parse import quote, urlencode
 
 import pyarrow as pa
 from sqlalchemy import (
@@ -55,20 +55,30 @@ logger = logging.getLogger(__name__)
 
 # SQLAlchemy dialect (matches ``self._driver``, set on connect from
 # ``runtime.driver``) -> dotted ADBC dbapi module path. Import is lazy
-# so a missing package simply disables the fast path for that dialect.
-# MySQL/MariaDB have no first-party ADBC driver today; the dispatch hook
-# is in place so a future ``adbc-driver-mysql`` (or a Flight SQL proxy
-# fronting MySQL via ``adbc-driver-flightsql``) can be wired in without
-# touching the handler.
+# so a missing package disables the fast path for that dialect.
 _ADBC_MODULES: Dict[str, str] = {
     "postgresql": "adbc_driver_postgresql.dbapi",
     "postgres": "adbc_driver_postgresql.dbapi",
 }
 
 
-# Opt-in feature flag. Set ``ADBC_FAST_PATH=1`` to enable. Anything else
-# (unset, ``0``, ``false``) keeps the SQLAlchemy path active.
+# Opt-in feature flag. ``ADBC_FAST_PATH=1`` enables the fast path.
 _ADBC_ENV_VAR = "ADBC_FAST_PATH"
+
+# Sentinel for ``_adbc_module``: distinct from ``None`` (never tried)
+# and from a real module object so an ``is`` check is unambiguous even
+# if a third-party module overrides ``__bool__``.
+_ADBC_IMPORT_FAILED: Any = object()
+
+
+class AdbcConfigurationError(RuntimeError):
+    """Deterministic ADBC-side misconfiguration.
+
+    Raised when retrying the same batch cannot succeed: missing driver
+    package, unsupported dialect, unbuildable URI, missing schema
+    contract. Surfaced as ``ACK_STATUS_FATAL_FAILURE`` so the engine
+    stops re-attempting.
+    """
 
 
 def _adbc_flag_enabled() -> bool:
@@ -170,14 +180,22 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
         # at startup.
         self._stream_endpoints: Dict[str, Dict[str, Any]] = {}
 
-        # Lazily-imported ADBC dbapi module (one per handler instance).
-        # ``None`` means we have not yet tried to import; ``False`` means
-        # the import failed once and we should not retry.
+        # Lazily-imported ADBC dbapi module. ``None`` means the import
+        # has not been attempted; ``_ADBC_IMPORT_FAILED`` means it was
+        # attempted and the package is unavailable in this process — we
+        # do not retry within the handler's lifetime.
         self._adbc_module: Any = None
-        # ADBC connection cached for the lifetime of this handler. ADBC
-        # connections are separate from the SQLAlchemy AsyncEngine pool;
-        # opened lazily on the first append batch, closed in disconnect().
+        # ADBC connection cached for the handler's lifetime. ADBC uses
+        # its own libpq transport, separate from the SQLAlchemy
+        # AsyncEngine pool. Opened lazily, nulled on any ingest error
+        # so the next batch reconnects instead of reusing a poisoned
+        # handle.
         self._adbc_conn: Any = None
+        # Set of ``(stream_id, reason)`` pairs that have already been
+        # logged when the fast path was demoted to SQLAlchemy. Keeps
+        # the demotion log to one line per stream per reason instead of
+        # one per batch.
+        self._adbc_demotion_logged: Set[Tuple[str, str]] = set()
 
     def set_endpoint_refs(self, endpoint_refs: Mapping[str, Any]) -> None:
         """Register stream_id → endpoint_ref for each stream writing to this
@@ -270,14 +288,25 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
         logger.info("DatabaseDestinationHandler connected to %s", self._driver)
 
     async def disconnect(self) -> None:
-        """Close database connection."""
-        if self._adbc_conn is not None:
-            adbc_conn = self._adbc_conn
-            self._adbc_conn = None
+        """Close database connection.
+
+        The SQLAlchemy runtime is released even if the ADBC close
+        fails, so we don't leak the engine on top of the ADBC handle.
+        ADBC close failures are surfaced at ERROR with ``exc_info`` —
+        they indicate a server-side resource may still be live.
+        """
+        adbc_conn = self._adbc_conn
+        if adbc_conn is not None:
             try:
                 await asyncio.to_thread(adbc_conn.close)
-            except Exception as exc:
-                logger.warning("Error closing ADBC connection: %s", exc)
+            except Exception:
+                logger.error(
+                    "Failed to close ADBC connection during disconnect; "
+                    "server-side resources may remain allocated",
+                    exc_info=True,
+                )
+            finally:
+                self._adbc_conn = None
         if self._runtime:
             await self._runtime.close()
         self._connected = False
@@ -562,14 +591,26 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
 
         try:
             if self._can_use_adbc(state):
-                # Append-only fast path. ADBC ingest and the
-                # ``_batch_commits`` write are intentionally split into
-                # two transactions — see ``_write_via_adbc`` for the
-                # idempotency trade-off this accepts.
                 await self._write_via_adbc(state, record_batch)
-                await self._record_batch_commit(
-                    state, run_id, stream_id, batch_seq, cursor.token, record_count
-                )
+                try:
+                    await self._record_batch_commit(
+                        state, run_id, stream_id, batch_seq,
+                        cursor.token, record_count,
+                    )
+                except Exception:
+                    # The ingest already committed on the ADBC
+                    # connection; we just failed to mark it in
+                    # ``_batch_commits``. A retry will pass the
+                    # pre-flight check and re-ingest, duplicating
+                    # the batch. Log loudly so operators can
+                    # correlate post-mortem.
+                    logger.error(
+                        "ADBC ingest committed but commit-record failed "
+                        "for %s/%s/%s — retry will duplicate %d row(s)",
+                        run_id, stream_id, batch_seq, record_count,
+                        exc_info=True,
+                    )
+                    raise
             else:
                 prepared = self._prepare_for_sqlalchemy(state, record_batch)
 
@@ -604,6 +645,15 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
                 status=AckStatus.ACK_STATUS_FATAL_FAILURE,
                 records_written=0,
                 failure_summary=f"type-map: {e}",
+            )
+        except AdbcConfigurationError as e:
+            # ADBC misconfiguration cannot heal between attempts; bail
+            # fatally so the engine does not retry forever.
+            logger.error("ADBC configuration error: %s", e, exc_info=True)
+            return BatchWriteResult(
+                status=AckStatus.ACK_STATUS_FATAL_FAILURE,
+                records_written=0,
+                failure_summary=f"adbc: {e}",
             )
         except Exception as e:
             logger.error(f"Error writing batch: {e}", exc_info=True)
@@ -762,38 +812,45 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
     def _load_adbc_module(self) -> Any:
         """Lazily import the ADBC dbapi module for the active dialect.
 
-        Returns the module, or ``False`` when no driver is registered for
-        the dialect or the import fails. The result is cached so a missing
-        package is logged once, not every batch.
+        Returns the module, or ``_ADBC_IMPORT_FAILED`` when no driver
+        is registered for the dialect or the import fails. The result
+        is cached so we do not retry an import that already failed
+        once in this process.
         """
         if self._adbc_module is not None:
             return self._adbc_module
 
         module_path = _ADBC_MODULES.get(self._driver)
         if not module_path:
-            self._adbc_module = False
-            return False
+            self._adbc_module = _ADBC_IMPORT_FAILED
+            return self._adbc_module
 
         try:
             self._adbc_module = importlib.import_module(module_path)
         except ImportError as exc:
-            logger.info(
+            # The flag was explicitly opted into, so a missing driver
+            # deserves WARNING — the user asked for the fast path and
+            # is silently getting the slow one otherwise.
+            log_fn = logger.warning if _adbc_flag_enabled() else logger.debug
+            log_fn(
                 "ADBC fast path disabled for driver=%s: %s not importable (%s). "
                 "Install the matching `adbc-driver-*` package to enable.",
                 self._driver,
                 module_path,
                 exc,
             )
-            self._adbc_module = False
+            self._adbc_module = _ADBC_IMPORT_FAILED
         return self._adbc_module
 
     def _build_adbc_uri(self) -> Optional[str]:
-        """Render the engine's URL as a libpq-style URI for ADBC.
+        """Render the SQLAlchemy URL as a libpq URI for ADBC.
 
-        SQLAlchemy renders ``postgresql+asyncpg://...``; ADBC expects
-        ``postgresql://...`` so we strip the ``+driver`` suffix and
-        URL-quote the credential parts so special characters in
-        passwords don't break the URI.
+        Reassembled from ``url`` parts so the leading driver name is
+        the bare backend (``postgresql``), credentials are
+        percent-encoded, and any non-empty ``url.query`` (e.g.
+        ``sslmode=require``, ``application_name=...``) is forwarded so
+        TLS / connection settings configured for SQLAlchemy are not
+        silently dropped for ADBC.
         """
         if self._engine is None:
             return None
@@ -811,48 +868,86 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
                 userinfo += ":" + quote(url.password, safe="")
             userinfo += "@"
         port = f":{url.port}" if url.port else ""
-        return f"postgresql://{userinfo}{url.host}{port}/{url.database}"
+
+        query = getattr(url, "query", None) or {}
+        query_string = ""
+        if query:
+            # SQLAlchemy ``url.query`` is a dict (or immutabledict)
+            # mapping str -> str | tuple[str, ...]. ``urlencode`` with
+            # ``doseq=True`` handles both.
+            query_string = "?" + urlencode(list(query.items()), doseq=True)
+
+        return f"postgresql://{userinfo}{url.host}{port}/{url.database}{query_string}"
+
+    def _note_adbc_demotion(self, state: _StreamState, reason: str) -> None:
+        """Log once per ``(stream_id, reason)`` why the fast path was
+        skipped. Only fires when the user actually asked for ADBC; if
+        the flag is off, demotion is the expected default and silent.
+        """
+        if not _adbc_flag_enabled():
+            return
+        key = (state.table_name or "", reason)
+        if key in self._adbc_demotion_logged:
+            return
+        self._adbc_demotion_logged.add(key)
+        logger.info(
+            "ADBC fast path disabled for table=%s.%s (driver=%s): %s",
+            state.schema_name,
+            state.table_name,
+            self._driver,
+            reason,
+        )
 
     def _can_use_adbc(self, state: _StreamState) -> bool:
-        """Decide whether the current batch should take the ADBC fast path.
+        """Decide whether the current batch takes the ADBC fast path.
 
         Gated on:
 
         * Opt-in feature flag (``ADBC_FAST_PATH`` env var).
-        * Append-only stream (``write_mode == "insert"``). Upsert and
-          truncate-insert keep the SQLAlchemy path; ``adbc_ingest`` is
-          INSERT/APPEND only.
-        * A registered ADBC driver for ``self._driver``.
-        * The driver package is importable.
+        * Append-only stream (``write_mode == "insert"``).
+          ``adbc_ingest`` is INSERT/APPEND only.
+        * The dialect is in ``_ADBC_MODULES`` and the matching driver
+          package is importable.
         * A connection URI can be built from the engine's URL.
-
-        Any single ``False`` short-circuits to the SQLAlchemy path —
-        the caller does not need to know which condition failed.
         """
         if not _adbc_flag_enabled():
             return False
         if state.write_mode != "insert":
+            self._note_adbc_demotion(
+                state, f"write_mode={state.write_mode!r} requires SQLAlchemy"
+            )
             return False
-        if self._driver not in _ADBC_MODULES:
-            return False
-        if not self._load_adbc_module():
+        if self._load_adbc_module() is _ADBC_IMPORT_FAILED:
+            self._note_adbc_demotion(
+                state, f"no ADBC driver registered for dialect={self._driver!r}"
+            )
             return False
         if self._build_adbc_uri() is None:
+            self._note_adbc_demotion(
+                state, "could not build ADBC URI from engine.url"
+            )
             return False
         return True
 
     def _open_adbc_connection(self) -> Any:
-        """Return the cached ADBC connection, opening it on first use."""
+        """Return the cached ADBC connection, opening it on first use.
+
+        Raises :class:`AdbcConfigurationError` when the driver module
+        or URI cannot be produced. The handler-side cache means the
+        connection persists across batches; ``_adbc_ingest_sync``
+        nulls it on any ingest error so a poisoned handle is not
+        reused.
+        """
         if self._adbc_conn is not None:
             return self._adbc_conn
         module = self._load_adbc_module()
-        if not module:
-            raise RuntimeError(
+        if module is _ADBC_IMPORT_FAILED:
+            raise AdbcConfigurationError(
                 f"ADBC module for driver={self._driver!r} not available"
             )
         uri = self._build_adbc_uri()
         if uri is None:
-            raise RuntimeError(
+            raise AdbcConfigurationError(
                 f"Could not build ADBC URI for driver={self._driver!r}"
             )
         self._adbc_conn = module.connect(uri)
@@ -866,22 +961,39 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
     ) -> None:
         """Synchronous ADBC ingest. Runs on a worker thread.
 
-        Uses ``adbc_ingest(..., mode="append")``. The target table must
-        already exist — ``configure_schema`` has emitted DDL via
-        SQLAlchemy by the time the first batch arrives.
+        Caller must ensure the target table exists.
+
+        On any exception (ingest itself, or cursor.close after a
+        successful ingest), invalidate ``self._adbc_conn`` so the next
+        batch reconnects. ADBC connection state after a backend error
+        is undefined — reusing it tends to produce a flapping retry
+        loop against an already-broken session.
         """
         conn = self._open_adbc_connection()
-        cursor = conn.cursor()
         try:
-            cursor.adbc_ingest(
-                table_name,
-                cast_batch,
-                mode="append",
-                db_schema_name=schema_name or None,
-            )
-            conn.commit()
-        finally:
-            cursor.close()
+            cursor = conn.cursor()
+            try:
+                cursor.adbc_ingest(
+                    table_name,
+                    cast_batch,
+                    mode="append",
+                    db_schema_name=schema_name or None,
+                )
+                conn.commit()
+            finally:
+                cursor.close()
+        except Exception:
+            poisoned = self._adbc_conn
+            self._adbc_conn = None
+            if poisoned is not None:
+                try:
+                    poisoned.close()
+                except Exception:
+                    # Best-effort. The conn is being discarded; the
+                    # original exception is what the caller cares
+                    # about.
+                    pass
+            raise
 
     async def _write_via_adbc(
         self,
@@ -895,15 +1007,15 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
         handed straight to ADBC — no ``to_pylist()`` round trip, no
         SQLAlchemy bind-parameter loop.
 
-        Idempotency caveat: the ingest commits on its own ADBC
+        Idempotency caveat: ``adbc_ingest`` commits on its own ADBC
         connection, then ``_batch_commits`` is recorded in a separate
         SQLAlchemy transaction. If the process dies between those two
-        commits, a retry will re-insert the batch. This is acceptable
-        for append-only streams; callers needing exactly-once should
-        stay on the SQLAlchemy path (``write_mode != "insert"``).
+        commits, a retry re-inserts the batch. This is acceptable for
+        append-only streams; callers needing exactly-once must stay on
+        the SQLAlchemy path (``write_mode != "insert"``).
         """
         if state.schema_contract is None:
-            raise RuntimeError(
+            raise AdbcConfigurationError(
                 "ADBC fast path requires a configured SchemaContract"
             )
         cast_batch = state.schema_contract.cast_arrow_batch(record_batch)

--- a/src/destination/connectors/database.py
+++ b/src/destination/connectors/database.py
@@ -8,10 +8,13 @@ efficient columnar type conversion for batch operations.
 """
 
 import asyncio
+import importlib
 import logging
+import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, Optional
+from urllib.parse import quote
 
 import pyarrow as pa
 from sqlalchemy import (
@@ -48,6 +51,29 @@ from ...shared.connection_runtime import ConnectionRuntime
 
 
 logger = logging.getLogger(__name__)
+
+
+# SQLAlchemy dialect (matches ``self._driver``, set on connect from
+# ``runtime.driver``) -> dotted ADBC dbapi module path. Import is lazy
+# so a missing package simply disables the fast path for that dialect.
+# MySQL/MariaDB have no first-party ADBC driver today; the dispatch hook
+# is in place so a future ``adbc-driver-mysql`` (or a Flight SQL proxy
+# fronting MySQL via ``adbc-driver-flightsql``) can be wired in without
+# touching the handler.
+_ADBC_MODULES: Dict[str, str] = {
+    "postgresql": "adbc_driver_postgresql.dbapi",
+    "postgres": "adbc_driver_postgresql.dbapi",
+}
+
+
+# Opt-in feature flag. Set ``ADBC_FAST_PATH=1`` to enable. Anything else
+# (unset, ``0``, ``false``) keeps the SQLAlchemy path active.
+_ADBC_ENV_VAR = "ADBC_FAST_PATH"
+
+
+def _adbc_flag_enabled() -> bool:
+    value = os.environ.get(_ADBC_ENV_VAR, "").strip().lower()
+    return value in ("1", "true", "yes", "on")
 
 
 @dataclass
@@ -144,6 +170,15 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
         # at startup.
         self._stream_endpoints: Dict[str, Dict[str, Any]] = {}
 
+        # Lazily-imported ADBC dbapi module (one per handler instance).
+        # ``None`` means we have not yet tried to import; ``False`` means
+        # the import failed once and we should not retry.
+        self._adbc_module: Any = None
+        # ADBC connection cached for the lifetime of this handler. ADBC
+        # connections are separate from the SQLAlchemy AsyncEngine pool;
+        # opened lazily on the first append batch, closed in disconnect().
+        self._adbc_conn: Any = None
+
     def set_endpoint_refs(self, endpoint_refs: Mapping[str, Any]) -> None:
         """Register stream_id → endpoint_ref for each stream writing to this
         destination. Called once by ``src.main`` before the gRPC server starts;
@@ -236,6 +271,13 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
 
     async def disconnect(self) -> None:
         """Close database connection."""
+        if self._adbc_conn is not None:
+            adbc_conn = self._adbc_conn
+            self._adbc_conn = None
+            try:
+                await asyncio.to_thread(adbc_conn.close)
+            except Exception as exc:
+                logger.warning("Error closing ADBC connection: %s", exc)
         if self._runtime:
             await self._runtime.close()
         self._connected = False
@@ -519,22 +561,32 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
             )
 
         try:
-            prepared = self._prepare_for_sqlalchemy(state, record_batch)
-
-            async with self._engine.begin() as conn:
-                if state.write_mode == "truncate_insert":
-                    await self._truncate_and_insert(conn, state, prepared)
-                elif state.write_mode == "upsert" and (
-                    state.conflict_keys or state.primary_keys
-                ):
-                    await self._upsert_records(conn, state, prepared)
-                else:
-                    await self._insert_records(conn, state, prepared)
-
-                # Record batch commit
-                await self._record_batch_commit_in_txn(
-                    conn, state, run_id, stream_id, batch_seq, cursor.token, record_count
+            if self._can_use_adbc(state):
+                # Append-only fast path. ADBC ingest and the
+                # ``_batch_commits`` write are intentionally split into
+                # two transactions — see ``_write_via_adbc`` for the
+                # idempotency trade-off this accepts.
+                await self._write_via_adbc(state, record_batch)
+                await self._record_batch_commit(
+                    state, run_id, stream_id, batch_seq, cursor.token, record_count
                 )
+            else:
+                prepared = self._prepare_for_sqlalchemy(state, record_batch)
+
+                async with self._engine.begin() as conn:
+                    if state.write_mode == "truncate_insert":
+                        await self._truncate_and_insert(conn, state, prepared)
+                    elif state.write_mode == "upsert" and (
+                        state.conflict_keys or state.primary_keys
+                    ):
+                        await self._upsert_records(conn, state, prepared)
+                    else:
+                        await self._insert_records(conn, state, prepared)
+
+                    # Record batch commit
+                    await self._record_batch_commit_in_txn(
+                        conn, state, run_id, stream_id, batch_seq, cursor.token, record_count
+                    )
 
             logger.info(f"Wrote batch {batch_seq}: {record_count} records")
             return BatchWriteResult(
@@ -702,6 +754,165 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
             return
         await conn.execute(state.table.delete())
         await self._insert_records(conn, state, records)
+
+    # ------------------------------------------------------------------
+    # ADBC fast path (append-only, opt-in)
+    # ------------------------------------------------------------------
+
+    def _load_adbc_module(self) -> Any:
+        """Lazily import the ADBC dbapi module for the active dialect.
+
+        Returns the module, or ``False`` when no driver is registered for
+        the dialect or the import fails. The result is cached so a missing
+        package is logged once, not every batch.
+        """
+        if self._adbc_module is not None:
+            return self._adbc_module
+
+        module_path = _ADBC_MODULES.get(self._driver)
+        if not module_path:
+            self._adbc_module = False
+            return False
+
+        try:
+            self._adbc_module = importlib.import_module(module_path)
+        except ImportError as exc:
+            logger.info(
+                "ADBC fast path disabled for driver=%s: %s not importable (%s). "
+                "Install the matching `adbc-driver-*` package to enable.",
+                self._driver,
+                module_path,
+                exc,
+            )
+            self._adbc_module = False
+        return self._adbc_module
+
+    def _build_adbc_uri(self) -> Optional[str]:
+        """Render the engine's URL as a libpq-style URI for ADBC.
+
+        SQLAlchemy renders ``postgresql+asyncpg://...``; ADBC expects
+        ``postgresql://...`` so we strip the ``+driver`` suffix and
+        URL-quote the credential parts so special characters in
+        passwords don't break the URI.
+        """
+        if self._engine is None:
+            return None
+        url = self._engine.url
+        backend = (url.get_backend_name() or "").lower()
+        if backend not in {"postgresql", "postgres"}:
+            return None
+        if not url.host or not url.database:
+            return None
+
+        userinfo = ""
+        if url.username:
+            userinfo = quote(url.username, safe="")
+            if url.password:
+                userinfo += ":" + quote(url.password, safe="")
+            userinfo += "@"
+        port = f":{url.port}" if url.port else ""
+        return f"postgresql://{userinfo}{url.host}{port}/{url.database}"
+
+    def _can_use_adbc(self, state: _StreamState) -> bool:
+        """Decide whether the current batch should take the ADBC fast path.
+
+        Gated on:
+
+        * Opt-in feature flag (``ADBC_FAST_PATH`` env var).
+        * Append-only stream (``write_mode == "insert"``). Upsert and
+          truncate-insert keep the SQLAlchemy path; ``adbc_ingest`` is
+          INSERT/APPEND only.
+        * A registered ADBC driver for ``self._driver``.
+        * The driver package is importable.
+        * A connection URI can be built from the engine's URL.
+
+        Any single ``False`` short-circuits to the SQLAlchemy path —
+        the caller does not need to know which condition failed.
+        """
+        if not _adbc_flag_enabled():
+            return False
+        if state.write_mode != "insert":
+            return False
+        if self._driver not in _ADBC_MODULES:
+            return False
+        if not self._load_adbc_module():
+            return False
+        if self._build_adbc_uri() is None:
+            return False
+        return True
+
+    def _open_adbc_connection(self) -> Any:
+        """Return the cached ADBC connection, opening it on first use."""
+        if self._adbc_conn is not None:
+            return self._adbc_conn
+        module = self._load_adbc_module()
+        if not module:
+            raise RuntimeError(
+                f"ADBC module for driver={self._driver!r} not available"
+            )
+        uri = self._build_adbc_uri()
+        if uri is None:
+            raise RuntimeError(
+                f"Could not build ADBC URI for driver={self._driver!r}"
+            )
+        self._adbc_conn = module.connect(uri)
+        return self._adbc_conn
+
+    def _adbc_ingest_sync(
+        self,
+        cast_batch: pa.RecordBatch,
+        schema_name: str,
+        table_name: str,
+    ) -> None:
+        """Synchronous ADBC ingest. Runs on a worker thread.
+
+        Uses ``adbc_ingest(..., mode="append")``. The target table must
+        already exist — ``configure_schema`` has emitted DDL via
+        SQLAlchemy by the time the first batch arrives.
+        """
+        conn = self._open_adbc_connection()
+        cursor = conn.cursor()
+        try:
+            cursor.adbc_ingest(
+                table_name,
+                cast_batch,
+                mode="append",
+                db_schema_name=schema_name or None,
+            )
+            conn.commit()
+        finally:
+            cursor.close()
+
+    async def _write_via_adbc(
+        self,
+        state: _StreamState,
+        record_batch: pa.RecordBatch,
+    ) -> None:
+        """Append-only fast path. INSERT via ``adbc_ingest``.
+
+        Reuses :meth:`SchemaContract.cast_arrow_batch` so the Arrow
+        types match the destination table exactly. The cast batch is
+        handed straight to ADBC — no ``to_pylist()`` round trip, no
+        SQLAlchemy bind-parameter loop.
+
+        Idempotency caveat: the ingest commits on its own ADBC
+        connection, then ``_batch_commits`` is recorded in a separate
+        SQLAlchemy transaction. If the process dies between those two
+        commits, a retry will re-insert the batch. This is acceptable
+        for append-only streams; callers needing exactly-once should
+        stay on the SQLAlchemy path (``write_mode != "insert"``).
+        """
+        if state.schema_contract is None:
+            raise RuntimeError(
+                "ADBC fast path requires a configured SchemaContract"
+            )
+        cast_batch = state.schema_contract.cast_arrow_batch(record_batch)
+        await asyncio.to_thread(
+            self._adbc_ingest_sync,
+            cast_batch,
+            state.schema_name,
+            state.table_name,
+        )
 
     def _prepare_for_sqlalchemy(
         self, state: _StreamState, record_batch: pa.RecordBatch

--- a/src/destination/connectors/database.py
+++ b/src/destination/connectors/database.py
@@ -81,6 +81,24 @@ class AdbcConfigurationError(RuntimeError):
     """
 
 
+class AdbcCommitRecordError(RuntimeError):
+    """ADBC ingest succeeded, but ``_batch_commits`` recording failed.
+
+    The data is already in the destination table. A retry will pass
+    the pre-flight idempotency check and ingest the batch again,
+    duplicating rows. The exception carries the inner error so the
+    engine's failure summary surfaces the divergence rather than a
+    generic commit error.
+    """
+
+    def __init__(self, inner: BaseException) -> None:
+        super().__init__(
+            f"adbc ingest committed; commit-record failed "
+            f"(retry will duplicate): {inner}"
+        )
+        self.__cause__ = inner
+
+
 def _adbc_flag_enabled() -> bool:
     value = os.environ.get(_ADBC_ENV_VAR, "").strip().lower()
     return value in ("1", "true", "yes", "on")
@@ -191,10 +209,10 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
         # so the next batch reconnects instead of reusing a poisoned
         # handle.
         self._adbc_conn: Any = None
-        # Set of ``(stream_id, reason)`` pairs that have already been
-        # logged when the fast path was demoted to SQLAlchemy. Keeps
-        # the demotion log to one line per stream per reason instead of
-        # one per batch.
+        # Set of ``(stream_id, reason)`` pairs already logged when the
+        # fast path was demoted to SQLAlchemy. Keyed on stream_id so
+        # two streams writing to the same physical table each get their
+        # own first-demotion log line.
         self._adbc_demotion_logged: Set[Tuple[str, str]] = set()
 
     def set_endpoint_refs(self, endpoint_refs: Mapping[str, Any]) -> None:
@@ -290,10 +308,12 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
     async def disconnect(self) -> None:
         """Close database connection.
 
-        The SQLAlchemy runtime is released even if the ADBC close
-        fails, so we don't leak the engine on top of the ADBC handle.
-        ADBC close failures are surfaced at ERROR with ``exc_info`` —
-        they indicate a server-side resource may still be live.
+        Both the ADBC connection and the SQLAlchemy runtime are
+        released even if the other side fails, so neither leaks on top
+        of the other. Close failures are logged at ERROR with
+        ``exc_info``; the handler still transitions to ``_connected =
+        False`` so callers can re-acquire without seeing a half-open
+        state.
         """
         adbc_conn = self._adbc_conn
         if adbc_conn is not None:
@@ -308,7 +328,13 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
             finally:
                 self._adbc_conn = None
         if self._runtime:
-            await self._runtime.close()
+            try:
+                await self._runtime.close()
+            except Exception:
+                logger.error(
+                    "Failed to close SQLAlchemy runtime during disconnect",
+                    exc_info=True,
+                )
         self._connected = False
         logger.info("DatabaseDestinationHandler disconnected")
 
@@ -590,27 +616,27 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
             )
 
         try:
-            if self._can_use_adbc(state):
+            if self._can_use_adbc(stream_id, state):
                 await self._write_via_adbc(state, record_batch)
                 try:
                     await self._record_batch_commit(
                         state, run_id, stream_id, batch_seq,
                         cursor.token, record_count,
                     )
-                except Exception:
+                except Exception as commit_exc:
                     # The ingest already committed on the ADBC
-                    # connection; we just failed to mark it in
-                    # ``_batch_commits``. A retry will pass the
-                    # pre-flight check and re-ingest, duplicating
-                    # the batch. Log loudly so operators can
-                    # correlate post-mortem.
+                    # connection; the SA ``_batch_commits`` write
+                    # failed. A retry will pass the pre-flight check
+                    # and re-ingest, duplicating rows. Surface the
+                    # divergence both in the log and in the failure
+                    # summary returned to the engine.
                     logger.error(
                         "ADBC ingest committed but commit-record failed "
                         "for %s/%s/%s — retry will duplicate %d row(s)",
                         run_id, stream_id, batch_seq, record_count,
                         exc_info=True,
                     )
-                    raise
+                    raise AdbcCommitRecordError(commit_exc) from commit_exc
             else:
                 prepared = self._prepare_for_sqlalchemy(state, record_batch)
 
@@ -879,26 +905,29 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
 
         return f"postgresql://{userinfo}{url.host}{port}/{url.database}{query_string}"
 
-    def _note_adbc_demotion(self, state: _StreamState, reason: str) -> None:
+    def _note_adbc_demotion(
+        self, stream_id: str, state: _StreamState, reason: str
+    ) -> None:
         """Log once per ``(stream_id, reason)`` why the fast path was
-        skipped. Only fires when the user actually asked for ADBC; if
-        the flag is off, demotion is the expected default and silent.
+        skipped. Silent when the flag is off — demotion is the default
+        and only worth surfacing when the user actually opted in.
         """
         if not _adbc_flag_enabled():
             return
-        key = (state.table_name or "", reason)
+        key = (stream_id, reason)
         if key in self._adbc_demotion_logged:
             return
         self._adbc_demotion_logged.add(key)
         logger.info(
-            "ADBC fast path disabled for table=%s.%s (driver=%s): %s",
+            "ADBC fast path disabled for stream=%s table=%s.%s (driver=%s): %s",
+            stream_id,
             state.schema_name,
             state.table_name,
             self._driver,
             reason,
         )
 
-    def _can_use_adbc(self, state: _StreamState) -> bool:
+    def _can_use_adbc(self, stream_id: str, state: _StreamState) -> bool:
         """Decide whether the current batch takes the ADBC fast path.
 
         Gated on:
@@ -914,17 +943,20 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
             return False
         if state.write_mode != "insert":
             self._note_adbc_demotion(
-                state, f"write_mode={state.write_mode!r} requires SQLAlchemy"
+                stream_id, state,
+                f"write_mode={state.write_mode!r} requires SQLAlchemy",
             )
             return False
         if self._load_adbc_module() is _ADBC_IMPORT_FAILED:
             self._note_adbc_demotion(
-                state, f"no ADBC driver registered for dialect={self._driver!r}"
+                stream_id, state,
+                f"no ADBC driver registered for dialect={self._driver!r}",
             )
             return False
         if self._build_adbc_uri() is None:
             self._note_adbc_demotion(
-                state, "could not build ADBC URI from engine.url"
+                stream_id, state,
+                "could not build ADBC URI from engine.url",
             )
             return False
         return True
@@ -989,10 +1021,14 @@ class DatabaseDestinationHandler(BaseDestinationHandler):
                 try:
                     poisoned.close()
                 except Exception:
-                    # Best-effort. The conn is being discarded; the
-                    # original exception is what the caller cares
-                    # about.
-                    pass
+                    # Best-effort. The conn is being discarded and the
+                    # original ingest exception is what the caller
+                    # needs to see; the close failure is logged at
+                    # DEBUG so a libpq leak still leaves evidence.
+                    logger.debug(
+                        "Discarded poisoned ADBC connection; close failed",
+                        exc_info=True,
+                    )
             raise
 
     async def _write_via_adbc(

--- a/tests/integration/test_database_connector_adbc.py
+++ b/tests/integration/test_database_connector_adbc.py
@@ -158,13 +158,12 @@ async def prepared_handler(pg_engine, table_name, monkeypatch):
     async with pg_engine.begin() as conn:
         await conn.execute(text(f"DROP TABLE IF EXISTS public.{table_name}"))
         await conn.execute(text(f"DROP TABLE IF EXISTS public.{table_name}_commits"))
-    # Close ADBC connection if opened. Test teardown — close failures
-    # are intentionally swallowed so a flaky close doesn't mask the
-    # real test result.
     if handler._adbc_conn is not None:
         try:
             handler._adbc_conn.close()
         except Exception:
+            # Test teardown — close failures are intentionally swallowed
+            # so a flaky close doesn't mask the real test result.
             pass
 
 

--- a/tests/integration/test_database_connector_adbc.py
+++ b/tests/integration/test_database_connector_adbc.py
@@ -12,7 +12,6 @@ import os
 import socket
 import uuid
 from typing import Any, Dict
-from unittest.mock import MagicMock
 
 import pyarrow as pa
 import pytest
@@ -159,7 +158,9 @@ async def prepared_handler(pg_engine, table_name, monkeypatch):
     async with pg_engine.begin() as conn:
         await conn.execute(text(f"DROP TABLE IF EXISTS public.{table_name}"))
         await conn.execute(text(f"DROP TABLE IF EXISTS public.{table_name}_commits"))
-    # Close ADBC connection if opened.
+    # Close ADBC connection if opened. Test teardown — close failures
+    # are intentionally swallowed so a flaky close doesn't mask the
+    # real test result.
     if handler._adbc_conn is not None:
         try:
             handler._adbc_conn.close()

--- a/tests/integration/test_database_connector_adbc.py
+++ b/tests/integration/test_database_connector_adbc.py
@@ -1,0 +1,232 @@
+"""Integration tests for the ADBC fast path in DatabaseDestinationHandler.
+
+Skipped automatically when either PostgreSQL is unreachable or the
+``adbc_driver_postgresql`` package is not importable. With both present
+this exercises the real ``adbc_ingest`` call against a live database.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import socket
+import uuid
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from src.destination.connectors.database import (
+    DatabaseDestinationHandler,
+    _StreamState,
+)
+from src.destination.schema_contract import SchemaContract
+from src.grpc.generated.analitiq.v1 import AckStatus, Cursor
+
+
+def _postgres_available() -> bool:
+    host = os.getenv("POSTGRES_HOST", "localhost")
+    port = int(os.getenv("POSTGRES_PORT", "5432"))
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+def _adbc_available() -> bool:
+    return importlib.util.find_spec("adbc_driver_postgresql") is not None
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _postgres_available(), reason="PostgreSQL not reachable"
+    ),
+    pytest.mark.skipif(
+        not _adbc_available(),
+        reason="adbc_driver_postgresql not installed",
+    ),
+]
+
+
+def _pg_url(driver: str = "postgresql+asyncpg") -> str:
+    host = os.getenv("POSTGRES_HOST", "localhost")
+    port = int(os.getenv("POSTGRES_PORT", "5432"))
+    db = os.getenv("POSTGRES_DB", "analitiq_test")
+    user = os.getenv("POSTGRES_USER", "postgres")
+    password = os.getenv("POSTGRES_PASSWORD", "")
+    cred = user + (f":{password}" if password else "")
+    return f"{driver}://{cred}@{host}:{port}/{db}"
+
+
+def _endpoint_document(table_name: str) -> Dict[str, Any]:
+    """Minimal database endpoint document for an int-id + string-name table."""
+    return {
+        "database_object": {"schema": "public", "name": table_name},
+        "primary_keys": ["id"],
+        "columns": [
+            {"name": "id", "native_type": "INTEGER", "arrow_type": "Int32",
+             "nullable": False},
+            {"name": "name", "native_type": "TEXT", "arrow_type": "Utf8",
+             "nullable": True},
+        ],
+    }
+
+
+@pytest.fixture
+async def pg_engine():
+    """Real AsyncEngine pointed at the local Postgres."""
+    engine = create_async_engine(_pg_url(), echo=False)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+def table_name() -> str:
+    return f"adbc_test_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+async def prepared_handler(pg_engine, table_name, monkeypatch):
+    """Build a handler with a real engine + pre-created target table.
+
+    The integration test exercises only the ADBC fast path, which assumes
+    the target table already exists (``configure_schema`` would normally
+    have emitted DDL via SQLAlchemy). Here we just create the table
+    directly to keep the test focused on the ADBC ingest call.
+    """
+    monkeypatch.setenv("ADBC_FAST_PATH", "1")
+
+    # Create the target + batch_commits tables.
+    async with pg_engine.begin() as conn:
+        await conn.execute(
+            text(f"CREATE TABLE public.{table_name} (id INTEGER PRIMARY KEY, name TEXT)")
+        )
+        await conn.execute(
+            text(
+                f"CREATE TABLE public.{table_name}_commits ("
+                "  run_id VARCHAR(255), stream_id VARCHAR(255),"
+                "  batch_seq BIGINT, committed_cursor BYTEA,"
+                "  records_written INTEGER, committed_at TIMESTAMP,"
+                "  PRIMARY KEY (run_id, stream_id, batch_seq)"
+                ")"
+            )
+        )
+
+    handler = DatabaseDestinationHandler()
+    handler._engine = pg_engine
+    handler._driver = "postgresql"
+    handler._connected = True
+
+    state = _StreamState(
+        schema_name="public",
+        table_name=table_name,
+        write_mode="insert",
+        primary_keys=["id"],
+    )
+    state.schema_contract = SchemaContract(_endpoint_document(table_name))
+
+    # Build SA Table objects matching what was created above so the
+    # batch-commit recorder can use them.
+    from sqlalchemy import (
+        Column, Integer, MetaData, String, Table, BigInteger,
+        LargeBinary, DateTime,
+    )
+    metadata = MetaData()
+    state.table = Table(
+        table_name, metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String),
+        schema="public",
+    )
+    state.batch_commits_table = Table(
+        f"{table_name}_commits", metadata,
+        Column("run_id", String(255), primary_key=True),
+        Column("stream_id", String(255), primary_key=True),
+        Column("batch_seq", BigInteger, primary_key=True),
+        Column("committed_cursor", LargeBinary),
+        Column("records_written", Integer),
+        Column("committed_at", DateTime),
+        schema="public",
+    )
+    handler._streams["s1"] = state
+
+    yield handler
+
+    async with pg_engine.begin() as conn:
+        await conn.execute(text(f"DROP TABLE IF EXISTS public.{table_name}"))
+        await conn.execute(text(f"DROP TABLE IF EXISTS public.{table_name}_commits"))
+    # Close ADBC connection if opened.
+    if handler._adbc_conn is not None:
+        try:
+            handler._adbc_conn.close()
+        except Exception:
+            pass
+
+
+class TestAdbcRealIngest:
+    @pytest.mark.asyncio
+    async def test_adbc_ingest_round_trip(self, prepared_handler, pg_engine, table_name):
+        """ADBC ingest writes rows; SQLAlchemy SELECT reads them back."""
+        batch = pa.RecordBatch.from_pydict({
+            "id": pa.array([1, 2, 3], type=pa.int32()),
+            "name": pa.array(["alpha", "beta", "gamma"], type=pa.string()),
+        })
+
+        result = await prepared_handler.write_batch(
+            run_id="r1",
+            stream_id="s1",
+            batch_seq=0,
+            record_batch=batch,
+            record_ids=["1", "2", "3"],
+            cursor=Cursor(token=b"cursor-0"),
+        )
+
+        assert result.status == AckStatus.ACK_STATUS_SUCCESS
+        assert result.records_written == 3
+
+        async with pg_engine.begin() as conn:
+            rows = (
+                await conn.execute(
+                    text(f"SELECT id, name FROM public.{table_name} ORDER BY id")
+                )
+            ).fetchall()
+        assert [(r.id, r.name) for r in rows] == [
+            (1, "alpha"), (2, "beta"), (3, "gamma"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_idempotency_replay_skips_reingest(
+        self, prepared_handler, pg_engine, table_name
+    ):
+        """Re-running the same (run_id, batch_seq) does not re-insert."""
+        batch = pa.RecordBatch.from_pydict({
+            "id": pa.array([1], type=pa.int32()),
+            "name": pa.array(["alpha"], type=pa.string()),
+        })
+
+        first = await prepared_handler.write_batch(
+            run_id="r1", stream_id="s1", batch_seq=0,
+            record_batch=batch, record_ids=["1"],
+            cursor=Cursor(token=b"cursor-0"),
+        )
+        assert first.status == AckStatus.ACK_STATUS_SUCCESS
+
+        second = await prepared_handler.write_batch(
+            run_id="r1", stream_id="s1", batch_seq=0,
+            record_batch=batch, record_ids=["1"],
+            cursor=Cursor(token=b"cursor-0"),
+        )
+        # Second call should be deduped by the pre-flight check.
+        assert second.status == AckStatus.ACK_STATUS_ALREADY_COMMITTED
+
+        async with pg_engine.begin() as conn:
+            count = (
+                await conn.execute(
+                    text(f"SELECT COUNT(*) AS c FROM public.{table_name}")
+                )
+            ).scalar()
+        assert count == 1

--- a/tests/unit/destination/handlers/test_database_handler_adbc.py
+++ b/tests/unit/destination/handlers/test_database_handler_adbc.py
@@ -18,7 +18,6 @@ import pytest
 from src.destination.connectors import database as database_module
 from src.destination.connectors.database import (
     _ADBC_IMPORT_FAILED,
-    AdbcCommitRecordError,
     AdbcConfigurationError,
     DatabaseDestinationHandler,
     _StreamState,

--- a/tests/unit/destination/handlers/test_database_handler_adbc.py
+++ b/tests/unit/destination/handlers/test_database_handler_adbc.py
@@ -1,0 +1,333 @@
+"""Unit tests for the ADBC fast path in DatabaseDestinationHandler.
+
+These tests exercise the gating predicate, the dispatch wiring inside
+``write_batch``, and the ``adbc_ingest`` invocation. ADBC itself is
+mocked — no real ADBC driver or database is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pyarrow as pa
+import pytest
+
+from src.destination.connectors import database as database_module
+from src.destination.connectors.database import (
+    DatabaseDestinationHandler,
+    _StreamState,
+)
+from src.grpc.generated.analitiq.v1 import AckStatus, Cursor
+
+
+def _state_with_contract(
+    write_mode: str = "insert",
+    schema_name: str = "public",
+    table_name: str = "events",
+) -> _StreamState:
+    state = _StreamState(
+        schema_name=schema_name,
+        table_name=table_name,
+        write_mode=write_mode,
+    )
+    # Provide a stub schema contract that returns the batch unchanged so
+    # the gating + dispatch tests don't depend on cast semantics.
+    contract = MagicMock()
+    contract.cast_arrow_batch = MagicMock(side_effect=lambda b: b)
+    state.schema_contract = contract
+    state.table = MagicMock()
+    state.batch_commits_table = MagicMock()
+    return state
+
+
+def _build_engine_url_mock(
+    backend: str = "postgresql",
+    host: str = "db.example.com",
+    port: int = 5432,
+    username: str = "u",
+    password: str = "p@ss/word",
+    database: str = "warehouse",
+) -> MagicMock:
+    url = SimpleNamespace(
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        database=database,
+        get_backend_name=lambda: backend,
+    )
+    engine = MagicMock()
+    engine.url = url
+    return engine
+
+
+@pytest.fixture
+def handler() -> DatabaseDestinationHandler:
+    h = DatabaseDestinationHandler()
+    h._driver = "postgresql"
+    h._engine = _build_engine_url_mock()
+    h._connected = True
+    return h
+
+
+@pytest.fixture
+def adbc_module_stub() -> MagicMock:
+    """Stand-in for ``adbc_driver_postgresql.dbapi``."""
+    module = MagicMock()
+    cursor = MagicMock()
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    module.connect.return_value = conn
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _disable_adbc_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default the env var to off so each test opts in explicitly."""
+    monkeypatch.delenv("ADBC_FAST_PATH", raising=False)
+
+
+class TestCanUseAdbc:
+    def test_default_flag_off_returns_false(self, handler):
+        state = _state_with_contract(write_mode="insert")
+        assert handler._can_use_adbc(state) is False
+
+    def test_upsert_returns_false(self, handler, monkeypatch, adbc_module_stub):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        with patch.object(
+            database_module.importlib,
+            "import_module",
+            return_value=adbc_module_stub,
+        ):
+            state = _state_with_contract(write_mode="upsert")
+            assert handler._can_use_adbc(state) is False
+
+    def test_truncate_insert_returns_false(self, handler, monkeypatch, adbc_module_stub):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        with patch.object(
+            database_module.importlib,
+            "import_module",
+            return_value=adbc_module_stub,
+        ):
+            state = _state_with_contract(write_mode="truncate_insert")
+            assert handler._can_use_adbc(state) is False
+
+    def test_unsupported_driver_returns_false(
+        self, handler, monkeypatch, adbc_module_stub
+    ):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._driver = "mysql"  # no ADBC module registered
+        with patch.object(
+            database_module.importlib,
+            "import_module",
+            return_value=adbc_module_stub,
+        ):
+            state = _state_with_contract(write_mode="insert")
+            assert handler._can_use_adbc(state) is False
+
+    def test_import_failure_returns_false(self, handler, monkeypatch):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        with patch.object(
+            database_module.importlib,
+            "import_module",
+            side_effect=ImportError("boom"),
+        ):
+            state = _state_with_contract(write_mode="insert")
+            assert handler._can_use_adbc(state) is False
+            # Cached as False so repeated calls don't re-import.
+            assert handler._adbc_module is False
+
+    def test_all_conditions_met_returns_true(
+        self, handler, monkeypatch, adbc_module_stub
+    ):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        with patch.object(
+            database_module.importlib,
+            "import_module",
+            return_value=adbc_module_stub,
+        ):
+            state = _state_with_contract(write_mode="insert")
+            assert handler._can_use_adbc(state) is True
+
+    def test_postgres_alias_dialect_matches(
+        self, handler, monkeypatch, adbc_module_stub
+    ):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._driver = "postgres"  # alias of postgresql
+        with patch.object(
+            database_module.importlib,
+            "import_module",
+            return_value=adbc_module_stub,
+        ):
+            state = _state_with_contract(write_mode="insert")
+            assert handler._can_use_adbc(state) is True
+
+
+class TestBuildAdbcUri:
+    def test_renders_libpq_uri_with_quoted_password(self, handler):
+        # Password contains characters that must be percent-encoded.
+        handler._engine = _build_engine_url_mock(password="p@ss/word")
+        uri = handler._build_adbc_uri()
+        assert uri == "postgresql://u:p%40ss%2Fword@db.example.com:5432/warehouse"
+
+    def test_returns_none_for_unsupported_backend(self, handler):
+        handler._engine = _build_engine_url_mock(backend="sqlite")
+        assert handler._build_adbc_uri() is None
+
+    def test_returns_none_when_host_missing(self, handler):
+        handler._engine = _build_engine_url_mock(host=None)
+        assert handler._build_adbc_uri() is None
+
+
+class TestWriteViaAdbc:
+    @pytest.mark.asyncio
+    async def test_cast_then_ingest(self, handler, adbc_module_stub):
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract()
+        batch = pa.RecordBatch.from_pydict({"id": [1, 2, 3]})
+
+        await handler._write_via_adbc(state, batch)
+
+        # cast happens exactly once
+        state.schema_contract.cast_arrow_batch.assert_called_once_with(batch)
+
+        # ADBC connect uses the URI built from the engine URL
+        adbc_module_stub.connect.assert_called_once()
+        connect_uri = adbc_module_stub.connect.call_args.args[0]
+        assert connect_uri.startswith("postgresql://")
+
+        # Ingest used append mode with the cast batch and table info
+        cursor = adbc_module_stub.connect.return_value.cursor.return_value
+        cursor.adbc_ingest.assert_called_once()
+        kwargs = cursor.adbc_ingest.call_args.kwargs
+        args = cursor.adbc_ingest.call_args.args
+        assert args[0] == "events"
+        assert args[1] is batch  # cast was a no-op stub
+        assert kwargs["mode"] == "append"
+        assert kwargs["db_schema_name"] == "public"
+
+        # Commit + cursor close
+        adbc_module_stub.connect.return_value.commit.assert_called_once()
+        cursor.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connection_is_reused_across_batches(
+        self, handler, adbc_module_stub
+    ):
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract()
+        batch = pa.RecordBatch.from_pydict({"id": [1]})
+
+        await handler._write_via_adbc(state, batch)
+        await handler._write_via_adbc(state, batch)
+
+        # One open, two ingest calls
+        assert adbc_module_stub.connect.call_count == 1
+        cursor = adbc_module_stub.connect.return_value.cursor.return_value
+        assert cursor.adbc_ingest.call_count == 2
+
+
+class TestWriteBatchDispatch:
+    @pytest.mark.asyncio
+    async def test_dispatches_to_adbc_when_gated_on(
+        self, handler, monkeypatch, adbc_module_stub
+    ):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._adbc_module = adbc_module_stub
+
+        state = _state_with_contract(write_mode="insert")
+        handler._streams["s1"] = state
+
+        # Idempotency check + commit recorder are both isolated SA paths;
+        # patch them so we don't need a real engine.
+        handler._check_batch_committed = AsyncMock(return_value=None)
+        handler._record_batch_commit = AsyncMock()
+
+        batch = pa.RecordBatch.from_pydict({"id": [1, 2]})
+        result = await handler.write_batch(
+            run_id="r1",
+            stream_id="s1",
+            batch_seq=0,
+            record_batch=batch,
+            record_ids=["1", "2"],
+            cursor=Cursor(token=b"tok"),
+        )
+
+        assert result.status == AckStatus.ACK_STATUS_SUCCESS
+        assert result.records_written == 2
+        # ADBC ingest fired; SA path was NOT touched (no engine.begin)
+        cursor = adbc_module_stub.connect.return_value.cursor.return_value
+        cursor.adbc_ingest.assert_called_once()
+        handler._record_batch_commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_sqlalchemy_when_flag_off(
+        self, handler, adbc_module_stub
+    ):
+        # Flag intentionally not set.
+        handler._adbc_module = adbc_module_stub
+
+        state = _state_with_contract(write_mode="insert")
+        handler._streams["s1"] = state
+
+        handler._check_batch_committed = AsyncMock(return_value=None)
+
+        # Mock the SA path: replace _prepare_for_sqlalchemy and _insert_records.
+        handler._prepare_for_sqlalchemy = MagicMock(return_value=[{"id": 1}])
+        handler._insert_records = AsyncMock()
+        handler._record_batch_commit_in_txn = AsyncMock()
+
+        # Mock the engine.begin() async context.
+        conn = AsyncMock()
+        begin_ctx = AsyncMock()
+        begin_ctx.__aenter__.return_value = conn
+        begin_ctx.__aexit__.return_value = None
+        handler._engine.begin = MagicMock(return_value=begin_ctx)
+
+        batch = pa.RecordBatch.from_pydict({"id": [1]})
+        result = await handler.write_batch(
+            run_id="r1",
+            stream_id="s1",
+            batch_seq=0,
+            record_batch=batch,
+            record_ids=["1"],
+            cursor=Cursor(token=b"tok"),
+        )
+
+        assert result.status == AckStatus.ACK_STATUS_SUCCESS
+        # ADBC path was never touched
+        adbc_module_stub.connect.assert_not_called()
+        # SA path ran
+        handler._insert_records.assert_awaited_once()
+
+
+class TestDisconnectClosesAdbc:
+    @pytest.mark.asyncio
+    async def test_closes_adbc_connection(self, handler):
+        adbc_conn = MagicMock()
+        handler._adbc_conn = adbc_conn
+        handler._runtime = AsyncMock()
+        handler._runtime.close = AsyncMock()
+
+        await handler.disconnect()
+
+        adbc_conn.close.assert_called_once()
+        assert handler._adbc_conn is None
+        assert handler._connected is False
+
+    @pytest.mark.asyncio
+    async def test_disconnect_tolerates_adbc_close_failure(self, handler):
+        adbc_conn = MagicMock()
+        adbc_conn.close.side_effect = RuntimeError("already closed")
+        handler._adbc_conn = adbc_conn
+        handler._runtime = AsyncMock()
+        handler._runtime.close = AsyncMock()
+
+        # Should not raise.
+        await handler.disconnect()
+
+        assert handler._adbc_conn is None
+        assert handler._connected is False

--- a/tests/unit/destination/handlers/test_database_handler_adbc.py
+++ b/tests/unit/destination/handlers/test_database_handler_adbc.py
@@ -1,15 +1,15 @@
 """Unit tests for the ADBC fast path in DatabaseDestinationHandler.
 
 These tests exercise the gating predicate, the dispatch wiring inside
-``write_batch``, and the ``adbc_ingest`` invocation. ADBC itself is
-mocked — no real ADBC driver or database is required.
+``write_batch``, idempotency-divergence logging, error classification,
+and the disconnect/cleanup contract. ADBC itself is mocked — no real
+ADBC driver or database is required.
 """
 
 from __future__ import annotations
 
-import asyncio
+import logging
 from types import SimpleNamespace
-from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pyarrow as pa
@@ -17,6 +17,8 @@ import pytest
 
 from src.destination.connectors import database as database_module
 from src.destination.connectors.database import (
+    _ADBC_IMPORT_FAILED,
+    AdbcConfigurationError,
     DatabaseDestinationHandler,
     _StreamState,
 )
@@ -33,8 +35,6 @@ def _state_with_contract(
         table_name=table_name,
         write_mode=write_mode,
     )
-    # Provide a stub schema contract that returns the batch unchanged so
-    # the gating + dispatch tests don't depend on cast semantics.
     contract = MagicMock()
     contract.cast_arrow_batch = MagicMock(side_effect=lambda b: b)
     state.schema_contract = contract
@@ -50,6 +50,7 @@ def _build_engine_url_mock(
     username: str = "u",
     password: str = "p@ss/word",
     database: str = "warehouse",
+    query: dict | None = None,
 ) -> MagicMock:
     url = SimpleNamespace(
         host=host,
@@ -57,6 +58,7 @@ def _build_engine_url_mock(
         username=username,
         password=password,
         database=database,
+        query=query or {},
         get_backend_name=lambda: backend,
     )
     engine = MagicMock()
@@ -97,38 +99,26 @@ class TestCanUseAdbc:
 
     def test_upsert_returns_false(self, handler, monkeypatch, adbc_module_stub):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
-        with patch.object(
-            database_module.importlib,
-            "import_module",
-            return_value=adbc_module_stub,
-        ):
-            state = _state_with_contract(write_mode="upsert")
-            assert handler._can_use_adbc(state) is False
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract(write_mode="upsert")
+        assert handler._can_use_adbc(state) is False
 
     def test_truncate_insert_returns_false(self, handler, monkeypatch, adbc_module_stub):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
-        with patch.object(
-            database_module.importlib,
-            "import_module",
-            return_value=adbc_module_stub,
-        ):
-            state = _state_with_contract(write_mode="truncate_insert")
-            assert handler._can_use_adbc(state) is False
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract(write_mode="truncate_insert")
+        assert handler._can_use_adbc(state) is False
 
-    def test_unsupported_driver_returns_false(
-        self, handler, monkeypatch, adbc_module_stub
-    ):
+    def test_unsupported_driver_returns_false(self, handler, monkeypatch):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
-        handler._driver = "mysql"  # no ADBC module registered
-        with patch.object(
-            database_module.importlib,
-            "import_module",
-            return_value=adbc_module_stub,
-        ):
-            state = _state_with_contract(write_mode="insert")
-            assert handler._can_use_adbc(state) is False
+        handler._driver = "mysql"
+        state = _state_with_contract(write_mode="insert")
+        assert handler._can_use_adbc(state) is False
+        # _load_adbc_module cached the import-failed sentinel for the
+        # unsupported dialect rather than attempting an import.
+        assert handler._adbc_module is _ADBC_IMPORT_FAILED
 
-    def test_import_failure_returns_false(self, handler, monkeypatch):
+    def test_import_failure_caches_sentinel(self, handler, monkeypatch):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
         with patch.object(
             database_module.importlib,
@@ -137,38 +127,89 @@ class TestCanUseAdbc:
         ):
             state = _state_with_contract(write_mode="insert")
             assert handler._can_use_adbc(state) is False
-            # Cached as False so repeated calls don't re-import.
-            assert handler._adbc_module is False
+            assert handler._adbc_module is _ADBC_IMPORT_FAILED
+
+    def test_import_failure_logs_warning_when_flag_on(
+        self, handler, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        with patch.object(
+            database_module.importlib,
+            "import_module",
+            side_effect=ImportError("boom"),
+        ):
+            with caplog.at_level(logging.WARNING, logger=database_module.logger.name):
+                handler._can_use_adbc(_state_with_contract(write_mode="insert"))
+        msgs = [r for r in caplog.records if "not importable" in r.message]
+        assert msgs, "expected a WARNING when the opted-in driver is missing"
+        assert msgs[0].levelno == logging.WARNING
+
+    def test_import_failure_logs_debug_when_flag_off(
+        self, handler, monkeypatch, caplog
+    ):
+        # No env var set. We still call _load_adbc_module directly to
+        # check the level: opt-out demotion is mundane.
+        with patch.object(
+            database_module.importlib,
+            "import_module",
+            side_effect=ImportError("boom"),
+        ):
+            with caplog.at_level(logging.DEBUG, logger=database_module.logger.name):
+                handler._load_adbc_module()
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not warnings
 
     def test_all_conditions_met_returns_true(
         self, handler, monkeypatch, adbc_module_stub
     ):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
-        with patch.object(
-            database_module.importlib,
-            "import_module",
-            return_value=adbc_module_stub,
-        ):
-            state = _state_with_contract(write_mode="insert")
-            assert handler._can_use_adbc(state) is True
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract(write_mode="insert")
+        assert handler._can_use_adbc(state) is True
 
     def test_postgres_alias_dialect_matches(
         self, handler, monkeypatch, adbc_module_stub
     ):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
-        handler._driver = "postgres"  # alias of postgresql
-        with patch.object(
-            database_module.importlib,
-            "import_module",
-            return_value=adbc_module_stub,
-        ):
-            state = _state_with_contract(write_mode="insert")
-            assert handler._can_use_adbc(state) is True
+        handler._driver = "postgres"  # `postgres+psycopg2` strips to `postgres`
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract(write_mode="insert")
+        assert handler._can_use_adbc(state) is True
+
+    def test_unbuildable_uri_returns_false(self, handler, monkeypatch, adbc_module_stub):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._adbc_module = adbc_module_stub
+        handler._engine = _build_engine_url_mock(host=None)
+        state = _state_with_contract(write_mode="insert")
+        assert handler._can_use_adbc(state) is False
+
+
+class TestDemotionLogging:
+    def test_logs_once_per_stream_and_reason(
+        self, handler, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._driver = "mysql"  # not in _ADBC_MODULES
+        state = _state_with_contract(write_mode="insert", table_name="events")
+        with caplog.at_level(logging.INFO, logger=database_module.logger.name):
+            for _ in range(5):
+                assert handler._can_use_adbc(state) is False
+        demotion_msgs = [
+            r for r in caplog.records
+            if "fast path disabled" in r.message and "no ADBC driver" in r.message
+        ]
+        assert len(demotion_msgs) == 1
+
+    def test_silent_when_flag_off(self, handler, caplog):
+        # Flag intentionally not set.
+        state = _state_with_contract(write_mode="upsert")
+        with caplog.at_level(logging.INFO, logger=database_module.logger.name):
+            handler._can_use_adbc(state)
+        assert not any("fast path disabled" in r.message for r in caplog.records)
 
 
 class TestBuildAdbcUri:
     def test_renders_libpq_uri_with_quoted_password(self, handler):
-        # Password contains characters that must be percent-encoded.
         handler._engine = _build_engine_url_mock(password="p@ss/word")
         uri = handler._build_adbc_uri()
         assert uri == "postgresql://u:p%40ss%2Fword@db.example.com:5432/warehouse"
@@ -181,42 +222,41 @@ class TestBuildAdbcUri:
         handler._engine = _build_engine_url_mock(host=None)
         assert handler._build_adbc_uri() is None
 
+    def test_forwards_query_params(self, handler):
+        handler._engine = _build_engine_url_mock(
+            query={"sslmode": "require", "application_name": "engine"}
+        )
+        uri = handler._build_adbc_uri()
+        assert uri is not None
+        assert uri.startswith("postgresql://u:p%40ss%2Fword@db.example.com:5432/warehouse?")
+        # Order-insensitive: both keys present, URL-encoded.
+        assert "sslmode=require" in uri
+        assert "application_name=engine" in uri
+
 
 class TestWriteViaAdbc:
     @pytest.mark.asyncio
-    async def test_cast_then_ingest(self, handler, adbc_module_stub):
+    async def test_passes_cast_output_not_raw_input(self, handler, adbc_module_stub):
         handler._adbc_module = adbc_module_stub
         state = _state_with_contract()
-        batch = pa.RecordBatch.from_pydict({"id": [1, 2, 3]})
+        # Replace cast with one that returns a distinct object so we
+        # can prove the cast result (not the raw input) reached ADBC.
+        raw = pa.RecordBatch.from_pydict({"id": [1, 2, 3]})
+        cast_out = pa.RecordBatch.from_pydict({"id": [9, 9, 9]})
+        state.schema_contract.cast_arrow_batch = MagicMock(return_value=cast_out)
 
-        await handler._write_via_adbc(state, batch)
+        await handler._write_via_adbc(state, raw)
 
-        # cast happens exactly once
-        state.schema_contract.cast_arrow_batch.assert_called_once_with(batch)
-
-        # ADBC connect uses the URI built from the engine URL
-        adbc_module_stub.connect.assert_called_once()
-        connect_uri = adbc_module_stub.connect.call_args.args[0]
-        assert connect_uri.startswith("postgresql://")
-
-        # Ingest used append mode with the cast batch and table info
         cursor = adbc_module_stub.connect.return_value.cursor.return_value
-        cursor.adbc_ingest.assert_called_once()
-        kwargs = cursor.adbc_ingest.call_args.kwargs
         args = cursor.adbc_ingest.call_args.args
         assert args[0] == "events"
-        assert args[1] is batch  # cast was a no-op stub
+        assert args[1] is cast_out
+        kwargs = cursor.adbc_ingest.call_args.kwargs
         assert kwargs["mode"] == "append"
         assert kwargs["db_schema_name"] == "public"
 
-        # Commit + cursor close
-        adbc_module_stub.connect.return_value.commit.assert_called_once()
-        cursor.close.assert_called_once()
-
     @pytest.mark.asyncio
-    async def test_connection_is_reused_across_batches(
-        self, handler, adbc_module_stub
-    ):
+    async def test_connection_is_reused_across_batches(self, handler, adbc_module_stub):
         handler._adbc_module = adbc_module_stub
         state = _state_with_contract()
         batch = pa.RecordBatch.from_pydict({"id": [1]})
@@ -224,10 +264,66 @@ class TestWriteViaAdbc:
         await handler._write_via_adbc(state, batch)
         await handler._write_via_adbc(state, batch)
 
-        # One open, two ingest calls
         assert adbc_module_stub.connect.call_count == 1
         cursor = adbc_module_stub.connect.return_value.cursor.return_value
         assert cursor.adbc_ingest.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_when_schema_contract_missing(self, handler, adbc_module_stub):
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract()
+        state.schema_contract = None
+        with pytest.raises(AdbcConfigurationError):
+            await handler._write_via_adbc(
+                state, pa.RecordBatch.from_pydict({"id": [1]})
+            )
+
+    @pytest.mark.asyncio
+    async def test_connect_failure_propagates_and_leaves_conn_unset(
+        self, handler, adbc_module_stub
+    ):
+        adbc_module_stub.connect.side_effect = RuntimeError("auth failed")
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract()
+        with pytest.raises(RuntimeError, match="auth failed"):
+            await handler._write_via_adbc(
+                state, pa.RecordBatch.from_pydict({"id": [1]})
+            )
+        assert handler._adbc_conn is None
+
+    @pytest.mark.asyncio
+    async def test_ingest_failure_invalidates_cached_connection(
+        self, handler, adbc_module_stub
+    ):
+        handler._adbc_module = adbc_module_stub
+        cursor = adbc_module_stub.connect.return_value.cursor.return_value
+        cursor.adbc_ingest.side_effect = RuntimeError("backend exploded")
+
+        state = _state_with_contract()
+        with pytest.raises(RuntimeError, match="backend exploded"):
+            await handler._write_via_adbc(
+                state, pa.RecordBatch.from_pydict({"id": [1]})
+            )
+
+        # Poisoned connection nulled + best-effort close attempted.
+        assert handler._adbc_conn is None
+        adbc_module_stub.connect.return_value.close.assert_called_once()
+
+        # A second batch reconnects rather than reusing the broken handle.
+        cursor.adbc_ingest.side_effect = None
+        await handler._write_via_adbc(
+            state, pa.RecordBatch.from_pydict({"id": [2]})
+        )
+        assert adbc_module_stub.connect.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_open_raises_adbc_error_when_module_missing(self, handler):
+        handler._driver = "mysql"  # not registered
+        state = _state_with_contract()
+        with pytest.raises(AdbcConfigurationError):
+            await handler._write_via_adbc(
+                state, pa.RecordBatch.from_pydict({"id": [1]})
+            )
 
 
 class TestWriteBatchDispatch:
@@ -237,28 +333,20 @@ class TestWriteBatchDispatch:
     ):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
         handler._adbc_module = adbc_module_stub
-
         state = _state_with_contract(write_mode="insert")
         handler._streams["s1"] = state
-
-        # Idempotency check + commit recorder are both isolated SA paths;
-        # patch them so we don't need a real engine.
         handler._check_batch_committed = AsyncMock(return_value=None)
         handler._record_batch_commit = AsyncMock()
 
         batch = pa.RecordBatch.from_pydict({"id": [1, 2]})
         result = await handler.write_batch(
-            run_id="r1",
-            stream_id="s1",
-            batch_seq=0,
-            record_batch=batch,
-            record_ids=["1", "2"],
+            run_id="r1", stream_id="s1", batch_seq=0,
+            record_batch=batch, record_ids=["1", "2"],
             cursor=Cursor(token=b"tok"),
         )
 
         assert result.status == AckStatus.ACK_STATUS_SUCCESS
         assert result.records_written == 2
-        # ADBC ingest fired; SA path was NOT touched (no engine.begin)
         cursor = adbc_module_stub.connect.return_value.cursor.return_value
         cursor.adbc_ingest.assert_called_once()
         handler._record_batch_commit.assert_awaited_once()
@@ -267,20 +355,13 @@ class TestWriteBatchDispatch:
     async def test_falls_back_to_sqlalchemy_when_flag_off(
         self, handler, adbc_module_stub
     ):
-        # Flag intentionally not set.
         handler._adbc_module = adbc_module_stub
-
         state = _state_with_contract(write_mode="insert")
         handler._streams["s1"] = state
-
         handler._check_batch_committed = AsyncMock(return_value=None)
-
-        # Mock the SA path: replace _prepare_for_sqlalchemy and _insert_records.
         handler._prepare_for_sqlalchemy = MagicMock(return_value=[{"id": 1}])
         handler._insert_records = AsyncMock()
         handler._record_batch_commit_in_txn = AsyncMock()
-
-        # Mock the engine.begin() async context.
         conn = AsyncMock()
         begin_ctx = AsyncMock()
         begin_ctx.__aenter__.return_value = conn
@@ -289,19 +370,70 @@ class TestWriteBatchDispatch:
 
         batch = pa.RecordBatch.from_pydict({"id": [1]})
         result = await handler.write_batch(
-            run_id="r1",
-            stream_id="s1",
-            batch_seq=0,
-            record_batch=batch,
-            record_ids=["1"],
+            run_id="r1", stream_id="s1", batch_seq=0,
+            record_batch=batch, record_ids=["1"],
             cursor=Cursor(token=b"tok"),
         )
 
         assert result.status == AckStatus.ACK_STATUS_SUCCESS
-        # ADBC path was never touched
         adbc_module_stub.connect.assert_not_called()
-        # SA path ran
         handler._insert_records.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_commit_record_failure_after_ingest_logs_and_returns_retryable(
+        self, handler, monkeypatch, adbc_module_stub, caplog
+    ):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract(write_mode="insert")
+        handler._streams["s1"] = state
+        handler._check_batch_committed = AsyncMock(return_value=None)
+        handler._record_batch_commit = AsyncMock(
+            side_effect=RuntimeError("commit-record table missing")
+        )
+
+        batch = pa.RecordBatch.from_pydict({"id": [1, 2, 3]})
+        with caplog.at_level(logging.ERROR, logger=database_module.logger.name):
+            result = await handler.write_batch(
+                run_id="r1", stream_id="s1", batch_seq=0,
+                record_batch=batch, record_ids=["1", "2", "3"],
+                cursor=Cursor(token=b"tok"),
+            )
+
+        # Outer except converts to retryable failure (engine retries it).
+        assert result.status == AckStatus.ACK_STATUS_RETRYABLE_FAILURE
+        # Ingest happened.
+        cursor = adbc_module_stub.connect.return_value.cursor.return_value
+        cursor.adbc_ingest.assert_called_once()
+        # Explicit warning about the duplication window.
+        divergence = [
+            r for r in caplog.records
+            if "retry will duplicate" in r.message
+        ]
+        assert divergence, "expected an ERROR-level log when commit-record fails after ingest"
+        assert divergence[0].levelno == logging.ERROR
+
+    @pytest.mark.asyncio
+    async def test_adbc_config_error_returns_fatal(
+        self, handler, monkeypatch, adbc_module_stub
+    ):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        # All gating passes (driver imported, URI fine, write_mode insert)
+        # but the schema contract is missing — a deterministic config error.
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract(write_mode="insert")
+        state.schema_contract = None
+        handler._streams["s1"] = state
+        handler._check_batch_committed = AsyncMock(return_value=None)
+
+        batch = pa.RecordBatch.from_pydict({"id": [1]})
+        result = await handler.write_batch(
+            run_id="r1", stream_id="s1", batch_seq=0,
+            record_batch=batch, record_ids=["1"],
+            cursor=Cursor(token=b"tok"),
+        )
+        assert result.status == AckStatus.ACK_STATUS_FATAL_FAILURE
+        assert "adbc:" in (result.failure_summary or "")
 
 
 class TestDisconnectClosesAdbc:
@@ -317,17 +449,31 @@ class TestDisconnectClosesAdbc:
         adbc_conn.close.assert_called_once()
         assert handler._adbc_conn is None
         assert handler._connected is False
+        handler._runtime.close.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_disconnect_tolerates_adbc_close_failure(self, handler):
+    async def test_close_failure_logged_at_error_and_runtime_still_released(
+        self, handler, caplog
+    ):
         adbc_conn = MagicMock()
         adbc_conn.close.side_effect = RuntimeError("already closed")
         handler._adbc_conn = adbc_conn
         handler._runtime = AsyncMock()
         handler._runtime.close = AsyncMock()
 
-        # Should not raise.
-        await handler.disconnect()
+        with caplog.at_level(logging.ERROR, logger=database_module.logger.name):
+            await handler.disconnect()
+
+        # ERROR with exc_info on a resource leak (was WARNING before).
+        errors = [
+            r for r in caplog.records
+            if "Failed to close ADBC connection" in r.message
+        ]
+        assert errors and errors[0].levelno == logging.ERROR
+        assert errors[0].exc_info is not None
 
         assert handler._adbc_conn is None
         assert handler._connected is False
+        # Engine is still released so we don't leak it on top of the
+        # ADBC handle.
+        handler._runtime.close.assert_awaited_once()

--- a/tests/unit/destination/handlers/test_database_handler_adbc.py
+++ b/tests/unit/destination/handlers/test_database_handler_adbc.py
@@ -213,9 +213,6 @@ class TestDemotionLogging:
     def test_two_streams_each_get_their_own_first_demotion_log(
         self, handler, monkeypatch, caplog
     ):
-        """Demotion cache keys on stream_id, so two streams writing to
-        the same physical table each see their own first-demotion line
-        rather than the second one being silently swallowed."""
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
         handler._driver = "mysql"  # not in _ADBC_MODULES
         state = _state_with_contract(write_mode="insert", table_name="events")
@@ -231,6 +228,36 @@ class TestDemotionLogging:
             for r in demotion_msgs
         )
         assert streams == ["stream-a", "stream-b"]
+
+    def test_same_stream_two_reasons_each_get_logged(
+        self, handler, monkeypatch, adbc_module_stub, caplog
+    ):
+        """A single stream demoted for two different reasons gets two
+        log lines — the cache key includes ``reason``, not just
+        ``stream_id``."""
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract(write_mode="upsert", table_name="events")
+        with caplog.at_level(logging.INFO, logger=database_module.logger.name):
+            # Reason 1: write_mode != insert
+            handler._can_use_adbc("stream-a", state)
+            # Reason 2: missing schema contract (after flipping mode)
+            state.write_mode = "insert"
+            state.schema_contract = None
+            handler._can_use_adbc("stream-a", state)
+        demotion_msgs = [
+            r for r in caplog.records if "fast path disabled" in r.message
+        ]
+        assert len(demotion_msgs) == 2
+
+    def test_missing_schema_contract_demotes(
+        self, handler, monkeypatch, adbc_module_stub
+    ):
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._adbc_module = adbc_module_stub
+        state = _state_with_contract(write_mode="insert")
+        state.schema_contract = None
+        assert handler._can_use_adbc("s1", state) is False
 
 
 class TestBuildAdbcUri:
@@ -257,6 +284,19 @@ class TestBuildAdbcUri:
         # Order-insensitive: both keys present, URL-encoded.
         assert "sslmode=require" in uri
         assert "application_name=engine" in uri
+
+    def test_forwards_tuple_valued_query_params(self, handler):
+        """SQLAlchemy URL.query maps a key to ``tuple[str, ...]`` for
+        multi-valued params (immutabledict shape). The builder uses
+        ``urlencode(..., doseq=True)`` so both values reach the URI
+        instead of only the first."""
+        handler._engine = _build_engine_url_mock(
+            query={"option": ("a", "b")}
+        )
+        uri = handler._build_adbc_uri()
+        assert uri is not None
+        assert "option=a" in uri
+        assert "option=b" in uri
 
 
 class TestWriteViaAdbc:
@@ -443,17 +483,56 @@ class TestWriteBatchDispatch:
         assert divergence[0].levelno == logging.ERROR
 
     @pytest.mark.asyncio
+    async def test_ingest_failure_does_not_wrap_in_commit_record_error(
+        self, handler, monkeypatch, adbc_module_stub
+    ):
+        """``AdbcCommitRecordError`` must signal *only* the "ingest
+        already committed" case. An ingest failure before any commit
+        must surface as the raw exception so the failure_summary
+        doesn't claim a duplicate-on-retry hazard that did not occur.
+        """
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._adbc_module = adbc_module_stub
+        cursor = adbc_module_stub.connect.return_value.cursor.return_value
+        cursor.adbc_ingest.side_effect = RuntimeError("ingest blew up")
+        state = _state_with_contract(write_mode="insert")
+        handler._streams["s1"] = state
+        handler._check_batch_committed = AsyncMock(return_value=None)
+        handler._record_batch_commit = AsyncMock()
+
+        batch = pa.RecordBatch.from_pydict({"id": [1]})
+        result = await handler.write_batch(
+            run_id="r1", stream_id="s1", batch_seq=0,
+            record_batch=batch, record_ids=["1"],
+            cursor=Cursor(token=b"tok"),
+        )
+
+        # Catch-all maps ingest failure to RETRYABLE.
+        assert result.status == AckStatus.ACK_STATUS_RETRYABLE_FAILURE
+        # failure_summary must not lie about an "ingest committed" event.
+        assert "adbc ingest committed" not in (result.failure_summary or "")
+        # commit-record was never invoked.
+        handler._record_batch_commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_adbc_config_error_returns_fatal(
         self, handler, monkeypatch, adbc_module_stub
     ):
+        """When a deterministic ADBC config error escapes the
+        dispatch (e.g. _open_adbc_connection raises mid-batch because
+        the driver was uninstalled at runtime), write_batch must
+        classify it as FATAL, not RETRYABLE."""
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
-        # All gating passes (driver imported, URI fine, write_mode insert)
-        # but the schema contract is missing — a deterministic config error.
         handler._adbc_module = adbc_module_stub
         state = _state_with_contract(write_mode="insert")
-        state.schema_contract = None
         handler._streams["s1"] = state
         handler._check_batch_committed = AsyncMock(return_value=None)
+
+        # Force _write_via_adbc to raise the deterministic error
+        # without going through the gated _open_adbc_connection path.
+        async def _raise(*_a, **_kw):
+            raise database_module.AdbcConfigurationError("driver missing")
+        handler._write_via_adbc = _raise  # type: ignore[assignment]
 
         batch = pa.RecordBatch.from_pydict({"id": [1]})
         result = await handler.write_batch(

--- a/tests/unit/destination/handlers/test_database_handler_adbc.py
+++ b/tests/unit/destination/handlers/test_database_handler_adbc.py
@@ -18,6 +18,7 @@ import pytest
 from src.destination.connectors import database as database_module
 from src.destination.connectors.database import (
     _ADBC_IMPORT_FAILED,
+    AdbcCommitRecordError,
     AdbcConfigurationError,
     DatabaseDestinationHandler,
     _StreamState,
@@ -95,25 +96,25 @@ def _disable_adbc_env(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestCanUseAdbc:
     def test_default_flag_off_returns_false(self, handler):
         state = _state_with_contract(write_mode="insert")
-        assert handler._can_use_adbc(state) is False
+        assert handler._can_use_adbc('s1', state) is False
 
     def test_upsert_returns_false(self, handler, monkeypatch, adbc_module_stub):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
         handler._adbc_module = adbc_module_stub
         state = _state_with_contract(write_mode="upsert")
-        assert handler._can_use_adbc(state) is False
+        assert handler._can_use_adbc('s1', state) is False
 
     def test_truncate_insert_returns_false(self, handler, monkeypatch, adbc_module_stub):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
         handler._adbc_module = adbc_module_stub
         state = _state_with_contract(write_mode="truncate_insert")
-        assert handler._can_use_adbc(state) is False
+        assert handler._can_use_adbc('s1', state) is False
 
     def test_unsupported_driver_returns_false(self, handler, monkeypatch):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
         handler._driver = "mysql"
         state = _state_with_contract(write_mode="insert")
-        assert handler._can_use_adbc(state) is False
+        assert handler._can_use_adbc('s1', state) is False
         # _load_adbc_module cached the import-failed sentinel for the
         # unsupported dialect rather than attempting an import.
         assert handler._adbc_module is _ADBC_IMPORT_FAILED
@@ -126,7 +127,7 @@ class TestCanUseAdbc:
             side_effect=ImportError("boom"),
         ):
             state = _state_with_contract(write_mode="insert")
-            assert handler._can_use_adbc(state) is False
+            assert handler._can_use_adbc('s1', state) is False
             assert handler._adbc_module is _ADBC_IMPORT_FAILED
 
     def test_import_failure_logs_warning_when_flag_on(
@@ -139,7 +140,9 @@ class TestCanUseAdbc:
             side_effect=ImportError("boom"),
         ):
             with caplog.at_level(logging.WARNING, logger=database_module.logger.name):
-                handler._can_use_adbc(_state_with_contract(write_mode="insert"))
+                handler._can_use_adbc(
+                    "s1", _state_with_contract(write_mode="insert")
+                )
         msgs = [r for r in caplog.records if "not importable" in r.message]
         assert msgs, "expected a WARNING when the opted-in driver is missing"
         assert msgs[0].levelno == logging.WARNING
@@ -165,7 +168,7 @@ class TestCanUseAdbc:
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
         handler._adbc_module = adbc_module_stub
         state = _state_with_contract(write_mode="insert")
-        assert handler._can_use_adbc(state) is True
+        assert handler._can_use_adbc('s1', state) is True
 
     def test_postgres_alias_dialect_matches(
         self, handler, monkeypatch, adbc_module_stub
@@ -174,14 +177,14 @@ class TestCanUseAdbc:
         handler._driver = "postgres"  # `postgres+psycopg2` strips to `postgres`
         handler._adbc_module = adbc_module_stub
         state = _state_with_contract(write_mode="insert")
-        assert handler._can_use_adbc(state) is True
+        assert handler._can_use_adbc('s1', state) is True
 
     def test_unbuildable_uri_returns_false(self, handler, monkeypatch, adbc_module_stub):
         monkeypatch.setenv("ADBC_FAST_PATH", "1")
         handler._adbc_module = adbc_module_stub
         handler._engine = _build_engine_url_mock(host=None)
         state = _state_with_contract(write_mode="insert")
-        assert handler._can_use_adbc(state) is False
+        assert handler._can_use_adbc('s1', state) is False
 
 
 class TestDemotionLogging:
@@ -193,7 +196,7 @@ class TestDemotionLogging:
         state = _state_with_contract(write_mode="insert", table_name="events")
         with caplog.at_level(logging.INFO, logger=database_module.logger.name):
             for _ in range(5):
-                assert handler._can_use_adbc(state) is False
+                assert handler._can_use_adbc('s1', state) is False
         demotion_msgs = [
             r for r in caplog.records
             if "fast path disabled" in r.message and "no ADBC driver" in r.message
@@ -204,8 +207,30 @@ class TestDemotionLogging:
         # Flag intentionally not set.
         state = _state_with_contract(write_mode="upsert")
         with caplog.at_level(logging.INFO, logger=database_module.logger.name):
-            handler._can_use_adbc(state)
+            handler._can_use_adbc('s1', state)
         assert not any("fast path disabled" in r.message for r in caplog.records)
+
+    def test_two_streams_each_get_their_own_first_demotion_log(
+        self, handler, monkeypatch, caplog
+    ):
+        """Demotion cache keys on stream_id, so two streams writing to
+        the same physical table each see their own first-demotion line
+        rather than the second one being silently swallowed."""
+        monkeypatch.setenv("ADBC_FAST_PATH", "1")
+        handler._driver = "mysql"  # not in _ADBC_MODULES
+        state = _state_with_contract(write_mode="insert", table_name="events")
+        with caplog.at_level(logging.INFO, logger=database_module.logger.name):
+            handler._can_use_adbc("stream-a", state)
+            handler._can_use_adbc("stream-b", state)
+        demotion_msgs = [
+            r for r in caplog.records if "fast path disabled" in r.message
+        ]
+        assert len(demotion_msgs) == 2
+        streams = sorted(
+            "stream-a" if "stream-a" in r.message else "stream-b"
+            for r in demotion_msgs
+        )
+        assert streams == ["stream-a", "stream-b"]
 
 
 class TestBuildAdbcUri:
@@ -402,10 +427,14 @@ class TestWriteBatchDispatch:
 
         # Outer except converts to retryable failure (engine retries it).
         assert result.status == AckStatus.ACK_STATUS_RETRYABLE_FAILURE
+        # The failure_summary keeps the "ingest already committed"
+        # signal so an operator looking at acks (or the DLQ) sees the
+        # duplicate-on-retry hazard, not a generic commit error.
+        assert "adbc ingest committed" in (result.failure_summary or "")
         # Ingest happened.
         cursor = adbc_module_stub.connect.return_value.cursor.return_value
         cursor.adbc_ingest.assert_called_once()
-        # Explicit warning about the duplication window.
+        # Explicit ERROR log about the duplication window.
         divergence = [
             r for r in caplog.records
             if "retry will duplicate" in r.message
@@ -477,3 +506,23 @@ class TestDisconnectClosesAdbc:
         # Engine is still released so we don't leak it on top of the
         # ADBC handle.
         handler._runtime.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_runtime_close_failure_still_flips_connected_state(
+        self, handler, caplog
+    ):
+        """If ``runtime.close()`` raises, the handler must still
+        transition to ``_connected = False`` so callers can re-acquire
+        without observing a half-disconnected state."""
+        handler._runtime = AsyncMock()
+        handler._runtime.close = AsyncMock(side_effect=RuntimeError("engine.dispose failed"))
+
+        with caplog.at_level(logging.ERROR, logger=database_module.logger.name):
+            await handler.disconnect()
+
+        errors = [
+            r for r in caplog.records
+            if "Failed to close SQLAlchemy runtime" in r.message
+        ]
+        assert errors and errors[0].levelno == logging.ERROR
+        assert handler._connected is False


### PR DESCRIPTION
## Summary

Adds an opt-in ADBC (Arrow Database Connectivity) write path to `DatabaseDestinationHandler`. Append-only INSERTs into Postgres can now bypass SQLAlchemy `executemany` and go through `adbc_ingest` directly, reusing the existing `SchemaContract.cast_arrow_batch` with no `to_pylist()` round trip. SQLAlchemy stays unchanged as the breadth layer for upserts, truncate-insert, and any dialect without an ADBC driver.

Motivation and design come from `docs1/pyarrow-and-destinations.md` — the recommendation was "one new method, dispatched by connector_slug, active only when `write.mode == \"insert\"` and an ADBC driver is importable."

## Activation

All of the following must be true:

- Env var `ADBC_FAST_PATH=1`
- `write.mode == "insert"` (append-only)
- Dialect is in `_ADBC_MODULES` (PostgreSQL today; hook reserved for MySQL/MariaDB)
- The matching `adbc-driver-*` package is importable

Anything else falls through to the existing SQLAlchemy path unchanged.

## Idempotency trade-off

ADBC commits on its own connection; `_batch_commits` is then written in a separate SQLAlchemy transaction. The pre-flight `_batch_commits` SELECT still gates retries, but if the process dies between the ADBC commit and the SA commit, a retry will re-insert the batch. This is acceptable for append-only streams and is documented in `_write_via_adbc`. Callers needing exactly-once stay on the SQLAlchemy path.

## Test plan

- [x] 16 new unit tests in `tests/unit/destination/handlers/test_database_handler_adbc.py` — all pass
- [x] 87 existing destination-handler unit tests still pass (SA path unchanged)
- [x] New integration test `tests/integration/test_database_connector_adbc.py` covers real PG ingest round-trip and idempotency replay; auto-skips when PG or ADBC driver is unavailable
- [x] Docker image rebuilds cleanly with the new optional deps installed
- [x] End-to-end pipelines verified in Docker (all use the default SA path with `ADBC_FAST_PATH` unset):
  - `wise-to-postgresql` — 68 records, success
  - `mysql-to-postgresql` — 15000 records / 15 batches, success
  - `mysql-to-postgresql-incremental` — 15000 records / 15 batches, success
  - `wise-to-sevdesk` — 68 records, success
  - `sevdesk-to-postgresql` — pre-existing stream-schema validation error in user-owned config, unrelated to this branch

## Files

- `src/destination/connectors/database.py` — `_ADBC_MODULES` registry, `_can_use_adbc` predicate, `_write_via_adbc` method, dispatch in `write_batch`, cleanup in `disconnect`
- `pyproject.toml` — `adbc-driver-manager` and `adbc-driver-postgresql` as optional deps; new `adbc` extras group
- `docker/requirements.txt` — same two packages so the image ships with them
- `tests/unit/destination/handlers/test_database_handler_adbc.py` — 16 new unit tests
- `tests/integration/test_database_connector_adbc.py` — 2 new integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)