### PR TITLE
Add org_id to ANALITIQ_* markers; fall back to 0 when ORG_ID/RUN_ID unset

### DIFF
--- a/src/state/dead_letter_queue.py
+++ b/src/state/dead_letter_queue.py
@@ -36,7 +36,7 @@ def emit_dlq_log(
     """
     data: Dict[str, Any] = {
         "type": "dlq",
-        "run_id": get_run_id(),
+        "run_id": get_run_id() or 0,
         "pipeline_id": pipeline_id,
         "added": added,
         "total": total,

--- a/src/state/dead_letter_queue.py
+++ b/src/state/dead_letter_queue.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from src.shared.run_id import get_run_id
 from src.state.log_emitter import emit_log
 
 logger = logging.getLogger(__name__)
@@ -29,13 +30,17 @@ def emit_dlq_log(
 ) -> None:
     """Emit a lightweight DLQ summary to stdout for observability.
 
-    Never emits record payloads -- only counts.
+    Never emits record payloads -- only counts. ``run_id`` and an
+    ISO-8601 UTC ``timestamp`` are included so downstream consumers can
+    correlate the summary back to the run that produced it.
     """
     data: Dict[str, Any] = {
         "type": "dlq",
+        "run_id": get_run_id(),
         "pipeline_id": pipeline_id,
         "added": added,
         "total": total,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     if stream_id:
         data["stream_id"] = stream_id

--- a/src/state/log_emitter.py
+++ b/src/state/log_emitter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import Any, Mapping
 
 logger = logging.getLogger(__name__)
@@ -29,14 +30,22 @@ def emit_log(category: str, data: Mapping[str, Any]) -> None:
     The record is JSON-serialised so collectors can ingest it directly.
     Unknown categories are still emitted (the marker falls back to the
     category name) but a debug warning is logged so the typo is visible.
+
+    ``org_id`` is injected from the ``ORG_ID`` environment variable into
+    every payload. The downstream pipeline-output-processor keys S3 paths
+    and DDB writes by ``org_id`` and drops records where it is missing.
     """
     marker = MARKERS.get(category)
     if marker is None:
         logger.debug("emit_log: unknown category %r — using as marker", category)
         marker = category.upper()
+    org_id = os.environ.get("ORG_ID")
+    enriched: dict[str, Any] = {"org_id": org_id, **dict(data)}
     try:
-        payload = json.dumps(dict(data), default=str)
+        payload = json.dumps(enriched, default=str)
     except (TypeError, ValueError) as err:
         logger.error("emit_log: payload not JSON-serialisable: %s", err)
-        payload = json.dumps({"error": str(err), "category": category})
+        payload = json.dumps(
+            {"org_id": org_id, "error": str(err), "category": category}
+        )
     logger.info("%s::%s", marker, payload)

--- a/src/state/log_emitter.py
+++ b/src/state/log_emitter.py
@@ -39,13 +39,11 @@ def emit_log(category: str, data: Mapping[str, Any]) -> None:
     if marker is None:
         logger.debug("emit_log: unknown category %r — using as marker", category)
         marker = category.upper()
-    org_id = os.environ.get("ORG_ID")
+    org_id = os.environ.get("ORG_ID") or 0
     enriched: dict[str, Any] = {"org_id": org_id, **dict(data)}
     try:
         payload = json.dumps(enriched, default=str)
     except (TypeError, ValueError) as err:
         logger.error("emit_log: payload not JSON-serialisable: %s", err)
-        payload = json.dumps(
-            {"org_id": org_id, "error": str(err), "category": category}
-        )
+        payload = json.dumps({"org_id": org_id, "error": str(err), "category": category})
     logger.info("%s::%s", marker, payload)


### PR DESCRIPTION
## Summary
- Inject `org_id` (from `ORG_ID` env var) into every `ANALITIQ_*` payload at the `emit_log` seam. The downstream pipeline-output-processor Lambda keys S3 paths and DDB writes by `org_id` and drops payloads where it is missing.
- Add `run_id` (from `get_run_id()`) and an ISO-8601 UTC `timestamp` to the `ANALITIQ_DLQ::` payload so DLQ summaries can be correlated with the run that produced them — matching the baseline identity fields already on the metrics and state markers.
- When `ORG_ID` or `RUN_ID` is unset, emit `0` instead of `null`. Some run contexts don't set these vars; emitting `null` was causing the Lambda to drop records that should land.

## Test plan
- [ ] Verify pipeline run with `ORG_ID` and `RUN_ID` set emits `"org_id": "<uuid>"` and `"run_id": "<id>"` in `ANALITIQ_METRICS::`, `ANALITIQ_STATE::`, and `ANALITIQ_DLQ::` lines.
- [ ] Verify pipeline run with `ORG_ID` and `RUN_ID` unset emits `"org_id": 0` and `"run_id": 0`.
- [ ] Confirm the downstream pipeline-output-processor stops logging `Pipeline metrics missing required fields: org_id=None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)